### PR TITLE
feat: add credit limit validation for order submissions

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.tsx
@@ -44,7 +44,7 @@ export const UnconnectedNavbar = ({ logout, pathname }: NavBarProps) => {
                         aria-label="Credits"
                         startIcon={<AccountBalanceWalletIcon />}
                     >
-                        Credits {creditsRemaining}
+                        Credits {Math.max(creditsRemaining, 0)}
                     </Button>
                 )}
                 {isParticipantOrAdmin && (

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
@@ -32,6 +32,8 @@ import { getCategories } from "slices/hardware/categorySlice";
 import { Grid } from "@material-ui/core";
 import { userTypeSelector } from "slices/users/userSlice";
 import DateRestrictionAlert from "components/general/DateRestrictionAlert/DateRestrictionAlert";
+import { getCurrentTeam } from "slices/event/teamSlice";
+import { getTeamOrders } from "slices/order/orderSlice";
 
 const Inventory = () => {
     const dispatch = useDispatch();
@@ -59,6 +61,11 @@ const Inventory = () => {
         dispatch(clearFilters());
         dispatch(getHardwareWithFilters());
         dispatch(getCategories());
+        // Reload team-related data for participants on page reload for accurate credit usage
+        if (userType === "participant") {
+            dispatch(getCurrentTeam());
+            dispatch(getTeamOrders());
+        }
     }, [dispatch]);
 
     return (

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
@@ -66,7 +66,7 @@ const Inventory = () => {
             dispatch(getCurrentTeam());
             dispatch(getTeamOrders());
         }
-    }, [dispatch]);
+    }, [dispatch, userType]);
 
     return (
         <>

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -281,6 +281,13 @@ class OrderCreateSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "User's team does not meet team size criteria"
             )
+
+        # Ensure user has a team
+        if not user_profile.team:
+            raise serializers.ValidationError("User does not belong to any team")
+
+        team = user_profile.team
+
         # requested_hardware is a Counter where the keys are <Hardware Object>'s
         # and values are <Int>'s
         requested_hardware = self.merge_requests(hardware_requests=data["hardware"])
@@ -304,6 +311,30 @@ class OrderCreateSerializer(serializers.Serializer):
         )
         category_counts = dict()
         error_messages = []
+
+        # Compute total credits already used by summing up all orders' credits
+        total_credits_used = sum(
+            order.get_total_credits()
+            for order in Order.objects.filter(team=team).exclude(status="Cancelled")
+        )
+
+        # Compute credits required for this new order
+        new_order_credits = sum(
+            hardware.credits * requested_quantity
+            for hardware, requested_quantity in requested_hardware.items()
+        )
+
+        # Compute remaining credits
+        remaining_credits = team.credits - total_credits_used
+        # Check if new order exceeds available credits
+        if new_order_credits > remaining_credits:
+            error_messages.append(
+                f"Order exceeds available team credits. "
+                f"Current available credits: {remaining_credits}. "
+                f"Requested credits: {new_order_credits}. "
+                f"Projected credits after order: {remaining_credits - new_order_credits}."
+            )
+
         for (hardware, requested_quantity) in requested_hardware.items():
             team_hardware = team_unreturned_orders.get(id=hardware.id)
             team_hardware_count = getattr(team_hardware, "past_order_count", 0)


### PR DESCRIPTION
## Overview

- Resolves #<number>
- add credit check in API when submitting an order as participant.


## Unit Tests Created

- n/a


## Steps to QA

- set disable = False for the CartSummary submit order button, and test an order that would exceed your credit limit. The API should reject this order and display the correct error message.

