### PR TITLE
feat: add credits to admin TeamDetail.tsx & handle return and update order state changes correctly

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/general/OrderTables/OrderTables.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/OrderTables/OrderTables.tsx
@@ -11,6 +11,7 @@ import Error from "@material-ui/icons/Error";
 import EditIcon from "@material-ui/icons/Edit";
 import UpdateIcon from "@material-ui/icons/Update";
 import {
+    Grid,
     Paper,
     Table,
     TableBody,
@@ -252,131 +253,169 @@ export const GeneralReturnTable = ({
                             : "Please bring items to the tech table and a tech team member will assist you."}
                     </Paper>
                 ) : (
-                    orders.map((order) => (
-                        <div
-                            key={order.id}
-                            data-testid={`returned-order-table-${order.id}`}
-                            data-updated-time={`returned-order-time-${order.hardwareInOrder[0].time}`}
-                        >
-                            <GeneralOrderTableTitle orderId={order.id} />
-                            <TableContainer
-                                component={Paper}
-                                elevation={2}
-                                square={true}
+                    orders.map((order) => {
+                        // Compute the subtotal for this order.
+                        const orderRefundedCredits = order.hardwareInOrder.reduce(
+                            (sum, row) => {
+                                const creditsPerUnit =
+                                    hardware[row.hardware_id]?.credits ?? 0;
+                                // If the item is Broken or Lost, its refunded credits are 0.
+                                const rowTotal =
+                                    row.part_returned_health === "Broken" ||
+                                    row.part_returned_health === "Lost"
+                                        ? 0
+                                        : row.quantity * creditsPerUnit;
+                                return sum + rowTotal;
+                            },
+                            0
+                        );
+                        return (
+                            <div
+                                key={order.id}
+                                data-testid={`returned-order-table-${order.id}`}
+                                data-updated-time={`returned-order-time-${order.hardwareInOrder[0].time}`}
                             >
-                                <Table
-                                    className={styles.table}
-                                    size="small"
-                                    aria-label="returned table"
+                                <GeneralOrderTableTitle orderId={order.id} />
+                                {/* Only show the credit subtotal if the user is admin */}
+                                {isAdmin && (
+                                    <Typography
+                                        variant="subtitle1"
+                                        color="textPrimary"
+                                        style={{
+                                            textAlign: "right",
+                                        }}
+                                    >
+                                        Total Credits Refunded: 💳{" "}
+                                        {orderRefundedCredits}
+                                    </Typography>
+                                )}
+                                <TableContainer
+                                    component={Paper}
+                                    elevation={2}
+                                    square={true}
                                 >
-                                    <TableHead>
-                                        <TableRow>
-                                            <TableCell className={styles.widthFixed} />
-                                            <TableCell
-                                                className={styles.width6}
-                                                align="left"
-                                            >
-                                                Name
-                                            </TableCell>
-                                            {isAdmin && (
+                                    <Table
+                                        className={styles.table}
+                                        size="small"
+                                        aria-label="returned table"
+                                    >
+                                        <TableHead>
+                                            <TableRow>
+                                                <TableCell
+                                                    className={styles.widthFixed}
+                                                />
+                                                <TableCell
+                                                    className={styles.width6}
+                                                    align="left"
+                                                >
+                                                    Name
+                                                </TableCell>
+                                                {isAdmin && (
+                                                    <TableCell
+                                                        className={styles.width4}
+                                                        align="right"
+                                                    >
+                                                        💳 Credits
+                                                    </TableCell>
+                                                )}
+                                                <TableCell
+                                                    className={styles.widthFixed}
+                                                    align="right"
+                                                >
+                                                    Qty
+                                                </TableCell>
                                                 <TableCell
                                                     className={styles.width4}
                                                     align="right"
                                                 >
-                                                    💳 Credits
+                                                    Time
                                                 </TableCell>
-                                            )}
-                                            <TableCell
-                                                className={styles.widthFixed}
-                                                align="right"
-                                            >
-                                                Qty
-                                            </TableCell>
-                                            <TableCell
-                                                className={styles.width4}
-                                                align="right"
-                                            >
-                                                Time
-                                            </TableCell>
-                                            <TableCell
-                                                align="left"
-                                                className={styles.width2}
-                                            >
-                                                Condition
-                                            </TableCell>
-                                        </TableRow>
-                                    </TableHead>
-                                    <TableBody>
-                                        {order.hardwareInOrder.map((row) => {
-                                            const creditsPerUnit =
-                                                hardware[row.hardware_id]?.credits ?? 0;
-                                            const totalCredits =
-                                                row.part_returned_health === "Lost" ||
-                                                row.part_returned_health === "Broken"
-                                                    ? 0
-                                                    : row.quantity * creditsPerUnit;
+                                                <TableCell
+                                                    align="left"
+                                                    className={styles.width2}
+                                                >
+                                                    Condition
+                                                </TableCell>
+                                            </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                            {order.hardwareInOrder.map((row) => {
+                                                const creditsPerUnit =
+                                                    hardware[row.hardware_id]
+                                                        ?.credits ?? 0;
+                                                const totalCredits =
+                                                    row.part_returned_health ===
+                                                        "Lost" ||
+                                                    row.part_returned_health ===
+                                                        "Broken"
+                                                        ? 0
+                                                        : row.quantity * creditsPerUnit;
 
-                                            return (
-                                                <TableRow key={row.id}>
-                                                    <TableCell align="left">
-                                                        <img
-                                                            className={styles.itemImg}
-                                                            src={
-                                                                hardware[
-                                                                    row.hardware_id
-                                                                ]?.picture ??
-                                                                hardware[
-                                                                    row.hardware_id
-                                                                ]?.image_url ??
-                                                                hardwareImagePlaceholder
-                                                            }
-                                                            alt={
+                                                return (
+                                                    <TableRow key={row.id}>
+                                                        <TableCell align="left">
+                                                            <img
+                                                                className={
+                                                                    styles.itemImg
+                                                                }
+                                                                src={
+                                                                    hardware[
+                                                                        row.hardware_id
+                                                                    ]?.picture ??
+                                                                    hardware[
+                                                                        row.hardware_id
+                                                                    ]?.image_url ??
+                                                                    hardwareImagePlaceholder
+                                                                }
+                                                                alt={
+                                                                    hardware[
+                                                                        row.hardware_id
+                                                                    ]?.name
+                                                                }
+                                                            />
+                                                        </TableCell>
+                                                        <TableCell align="left">
+                                                            {
                                                                 hardware[
                                                                     row.hardware_id
                                                                 ]?.name
                                                             }
-                                                        />
-                                                    </TableCell>
-                                                    <TableCell align="left">
-                                                        {
-                                                            hardware[row.hardware_id]
-                                                                ?.name
-                                                        }
-                                                    </TableCell>
-                                                    {isAdmin && (
+                                                        </TableCell>
+                                                        {isAdmin && (
+                                                            <TableCell
+                                                                align="right"
+                                                                style={{
+                                                                    fontWeight: "bold",
+                                                                    color: "#28a745", // Green for refunded credits
+                                                                }}
+                                                            >
+                                                                {totalCredits}
+                                                            </TableCell>
+                                                        )}
+                                                        <TableCell align="right">
+                                                            {row.quantity}
+                                                        </TableCell>
                                                         <TableCell
                                                             align="right"
-                                                            style={{
-                                                                fontWeight: "bold",
-                                                                color: "#28a745", // Green for refunded credits
-                                                            }}
+                                                            className={styles.noWrap}
                                                         >
-                                                            {totalCredits}
+                                                            {row.time}
                                                         </TableCell>
-                                                    )}
-                                                    <TableCell align="right">
-                                                        {row.quantity}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="right"
-                                                        className={styles.noWrap}
-                                                    >
-                                                        {row.time}
-                                                    </TableCell>
-                                                    <TableCell
-                                                        align="left"
-                                                        className={styles.noWrap}
-                                                    >
-                                                        {row.part_returned_health}
-                                                    </TableCell>
-                                                </TableRow>
-                                            );
-                                        })}
-                                    </TableBody>
-                                </Table>
-                            </TableContainer>
-                        </div>
-                    ))
+                                                        <TableCell
+                                                            align="left"
+                                                            className={styles.noWrap}
+                                                        >
+                                                            {row.part_returned_health}
+                                                        </TableCell>
+                                                    </TableRow>
+                                                );
+                                            })}
+                                        </TableBody>
+                                    </Table>
+                                </TableContainer>
+                            </div>
+                        );
+                    })
                 ))}
         </Container>
     );

--- a/hackathon_site/dashboard/frontend/src/components/general/OrderTables/OrderTables.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/OrderTables/OrderTables.tsx
@@ -23,6 +23,7 @@ import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-ima
 import { useSelector } from "react-redux";
 import { hardwareSelectors } from "slices/hardware/hardwareSlice";
 import { formatDateTime } from "api/helpers";
+import { userTypeSelector } from "slices/users/userSlice";
 
 export const ChipStatus = ({ status }: { status: OrderStatus | "Error" }) => {
     switch (status) {
@@ -227,6 +228,7 @@ export const GeneralReturnTable = ({
     fetchOrdersError?: string | null;
 }) => {
     const hardware = useSelector(hardwareSelectors.selectEntities);
+    const isAdmin = useSelector(userTypeSelector) === "admin";
 
     return (
         <Container
@@ -276,6 +278,14 @@ export const GeneralReturnTable = ({
                                             >
                                                 Name
                                             </TableCell>
+                                            {isAdmin && (
+                                                <TableCell
+                                                    className={styles.width4}
+                                                    align="right"
+                                                >
+                                                    💳 Credits
+                                                </TableCell>
+                                            )}
                                             <TableCell
                                                 className={styles.widthFixed}
                                                 align="right"
@@ -297,44 +307,71 @@ export const GeneralReturnTable = ({
                                         </TableRow>
                                     </TableHead>
                                     <TableBody>
-                                        {order.hardwareInOrder.map((row) => (
-                                            <TableRow key={row.id}>
-                                                <TableCell align="left">
-                                                    <img
-                                                        className={styles.itemImg}
-                                                        src={
-                                                            hardware[row.hardware_id]
-                                                                ?.picture ??
-                                                            hardware[row.hardware_id]
-                                                                ?.image_url ??
-                                                            hardwareImagePlaceholder
-                                                        }
-                                                        alt={
+                                        {order.hardwareInOrder.map((row) => {
+                                            const creditsPerUnit =
+                                                hardware[row.hardware_id]?.credits ?? 0;
+                                            const totalCredits =
+                                                row.part_returned_health === "Lost" ||
+                                                row.part_returned_health === "Broken"
+                                                    ? 0
+                                                    : row.quantity * creditsPerUnit;
+
+                                            return (
+                                                <TableRow key={row.id}>
+                                                    <TableCell align="left">
+                                                        <img
+                                                            className={styles.itemImg}
+                                                            src={
+                                                                hardware[
+                                                                    row.hardware_id
+                                                                ]?.picture ??
+                                                                hardware[
+                                                                    row.hardware_id
+                                                                ]?.image_url ??
+                                                                hardwareImagePlaceholder
+                                                            }
+                                                            alt={
+                                                                hardware[
+                                                                    row.hardware_id
+                                                                ]?.name
+                                                            }
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell align="left">
+                                                        {
                                                             hardware[row.hardware_id]
                                                                 ?.name
                                                         }
-                                                    />
-                                                </TableCell>
-                                                <TableCell align="left">
-                                                    {hardware[row.hardware_id]?.name}
-                                                </TableCell>
-                                                <TableCell align="right">
-                                                    {row.quantity}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="right"
-                                                    className={styles.noWrap}
-                                                >
-                                                    {row.time}
-                                                </TableCell>
-                                                <TableCell
-                                                    align="left"
-                                                    className={styles.noWrap}
-                                                >
-                                                    {row.part_returned_health}
-                                                </TableCell>
-                                            </TableRow>
-                                        ))}
+                                                    </TableCell>
+                                                    {isAdmin && (
+                                                        <TableCell
+                                                            align="right"
+                                                            style={{
+                                                                fontWeight: "bold",
+                                                                color: "#28a745", // Green for refunded credits
+                                                            }}
+                                                        >
+                                                            {totalCredits}
+                                                        </TableCell>
+                                                    )}
+                                                    <TableCell align="right">
+                                                        {row.quantity}
+                                                    </TableCell>
+                                                    <TableCell
+                                                        align="right"
+                                                        className={styles.noWrap}
+                                                    >
+                                                        {row.time}
+                                                    </TableCell>
+                                                    <TableCell
+                                                        align="left"
+                                                        className={styles.noWrap}
+                                                    >
+                                                        {row.part_returned_health}
+                                                    </TableCell>
+                                                </TableRow>
+                                            );
+                                        })}
                                     </TableBody>
                                 </Table>
                             </TableContainer>

--- a/hackathon_site/dashboard/frontend/src/components/general/OrderTables/OrderTables.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/OrderTables/OrderTables.tsx
@@ -8,10 +8,10 @@ import Chip from "@material-ui/core/Chip";
 import CheckCircle from "@material-ui/icons/CheckCircle";
 import WatchLater from "@material-ui/icons/WatchLater";
 import Error from "@material-ui/icons/Error";
+import MoneyOff from "@material-ui/icons/MoneyOff";
 import EditIcon from "@material-ui/icons/Edit";
 import UpdateIcon from "@material-ui/icons/Update";
 import {
-    Grid,
     Paper,
     Table,
     TableBody,
@@ -26,7 +26,14 @@ import { hardwareSelectors } from "slices/hardware/hardwareSlice";
 import { formatDateTime } from "api/helpers";
 import { userTypeSelector } from "slices/users/userSlice";
 
-export const ChipStatus = ({ status }: { status: OrderStatus | "Error" }) => {
+// Extend the props to include an optional "overLimit" boolean.
+export const ChipStatus = ({
+    status,
+    overLimit,
+}: {
+    status: OrderStatus | "Error";
+    overLimit?: boolean;
+}) => {
     switch (status) {
         case "Ready for Pickup":
             return (
@@ -38,11 +45,20 @@ export const ChipStatus = ({ status }: { status: OrderStatus | "Error" }) => {
             );
         case "Submitted":
             return (
-                <Chip
-                    icon={<WatchLater />}
-                    label="In progress"
-                    className={`${styles.chipOrange} ${styles.chip}`}
-                />
+                <>
+                    <Chip
+                        icon={<WatchLater />}
+                        label="In progress"
+                        className={`${styles.chipOrange} ${styles.chip}`}
+                    />
+                    {overLimit && (
+                        <Chip
+                            icon={<MoneyOff />}
+                            label="Over credit limit"
+                            className={`${styles.chipRed} ${styles.chip}`}
+                        />
+                    )}
+                </>
             );
         case "Error":
             return (
@@ -89,6 +105,7 @@ interface GeneralOrderTableTitleProps {
     createdTime?: string;
     updatedTime?: string;
     additionalChipFormatting?: boolean;
+    overLimit?: boolean;
 }
 
 export const GeneralOrderTableTitle = ({
@@ -97,6 +114,7 @@ export const GeneralOrderTableTitle = ({
     createdTime,
     updatedTime,
     additionalChipFormatting,
+    overLimit,
 }: GeneralOrderTableTitleProps) => (
     <Container className={styles.titleChip} maxWidth={false} disableGutters={true}>
         <Typography variant="h2" className={styles.titleChipText}>
@@ -109,7 +127,7 @@ export const GeneralOrderTableTitle = ({
                 maxWidth={false}
                 disableGutters={true}
             >
-                <ChipStatus status={orderStatus} />
+                <ChipStatus status={orderStatus} overLimit={overLimit} />
             </Container>
         )}
 

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
@@ -284,6 +284,7 @@ interface MainSectionProps {
     quantityRemaining: number;
     categories: string[];
     picture: string;
+    credits: number;
 }
 const MainSection = ({
     name,
@@ -291,6 +292,7 @@ const MainSection = ({
     quantityRemaining,
     categories,
     picture,
+    credits,
 }: MainSectionProps) => {
     const userType = useSelector(userTypeSelector);
     const availability =
@@ -311,6 +313,11 @@ const MainSection = ({
             <div>
                 <Typography variant="h6">{name}</Typography>
                 {availability}
+                {credits && (
+                    <Typography variant="body2" className={styles.credits}>
+                        Credits: {credits}
+                    </Typography>
+                )}
                 {categories.length > 0 && (
                     <>
                         <Typography variant="body2" className={styles.heading}>
@@ -409,6 +416,7 @@ export const ProductOverview = ({
                                 hardware.image_url ??
                                 hardwareImagePlaceholder
                             }
+                            credits={hardware.credits}
                         />
                         <DetailInfoSection
                             manufacturer={hardware.manufacturer}

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
@@ -120,7 +120,7 @@ export const TeamCheckedOutOrderTable = () => {
                 throw new Error("Order not found.");
             }
 
-            // Convert Formik values to the correct format
+            // Convert Formik values to the correct format, but filter out hardware that is already fully returned.
             const hardwareReturnData: {
                 id: number;
                 quantity: number;
@@ -129,19 +129,41 @@ export const TeamCheckedOutOrderTable = () => {
             const keys = Object.keys(values);
             for (let i = 0; i < keys.length; i += 3) {
                 const id = parseInt(keys[i].split("-")[0]);
+                // Only process if the checkbox (or whatever flag) is checked
                 if (values[keys[i + 1]]) {
-                    hardwareReturnData.push({
-                        id,
-                        quantity: parseInt(values[keys[i]] as string, 10),
-                        part_returned_health: values[keys[i + 2]] as string,
-                    });
+                    const quantityToReturn = parseInt(values[keys[i]] as string, 10);
+
+                    // Look up the hardware row in the checked out order
+                    const hardwareRow = checkedOutOrder.hardwareInTableRow.find(
+                        (row) => row.id === id
+                    );
+                    // If the hardwareRow exists and its remaining quantity is greater than zero, include it.
+                    if (hardwareRow && hardwareRow.quantityGranted > 0) {
+                        // You might also want to ensure that quantityToReturn does not exceed the remaining quantity.
+                        hardwareReturnData.push({
+                            id,
+                            quantity: Math.min(
+                                quantityToReturn,
+                                hardwareRow.quantityGranted
+                            ),
+                            part_returned_health: values[keys[i + 2]] as string,
+                        });
+                    }
                 }
             }
 
-            dispatch(returnItems({ hardware: hardwareReturnData, order: orderId }));
+            // Only dispatch returnItems if there's at least one valid hardware return.
+            if (hardwareReturnData.length > 0) {
+                dispatch(returnItems({ hardware: hardwareReturnData, order: orderId }));
+            } else {
+                // Otherwise, you might choose to directly update the order status
+                dispatch(updateOrderStatus({ id: orderId, status: "Returned" }));
+                return;
+            }
 
-            // Check if all items in the order have been returned
+            // Check if all items in the order have been returned.
             const allItemsReturned = checkedOutOrder.hardwareInTableRow.every((row) => {
+                // Calculate how many of this hardware have been returned (from the current request)
                 const returnedQuantity =
                     hardwareReturnData.find((h) => h.id === row.id)?.quantity || 0;
                 const remainingQty = (row.quantityGranted || 0) - returnedQuantity;

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
@@ -212,344 +212,412 @@ export const TeamCheckedOutOrderTable = () => {
                             }}
                             key={checkedOutOrder.id}
                         >
-                            {(props) => (
-                                <form onSubmit={props.handleSubmit}>
-                                    <div key={checkedOutOrder.id}>
-                                        <GeneralOrderTableTitle
-                                            orderId={checkedOutOrder.id}
-                                            orderStatus={checkedOutOrder.status}
-                                            createdTime={checkedOutOrder.createdTime}
-                                            updatedTime={checkedOutOrder.updatedTime}
-                                        />
-                                        <TableContainer
-                                            component={Paper}
-                                            elevation={2}
-                                            square={true}
-                                        >
-                                            <Table
-                                                className={styles.table}
-                                                size="small"
+                            {(props) => {
+                                // Compute the credit subtotal for the order.
+                                const orderTotalCredits =
+                                    checkedOutOrder.hardwareInTableRow.reduce(
+                                        (sum, row) => {
+                                            // Convert the Formik value to a number.
+                                            const formikQuantity = Number(
+                                                props.values[`${row.id}-quantity`]
+                                            );
+                                            // Determine the selected quantity:
+                                            const selectedQuantity =
+                                                selectedReturnQuantities[row.id] !==
+                                                undefined
+                                                    ? selectedReturnQuantities[row.id]
+                                                    : isNaN(formikQuantity)
+                                                    ? row.quantityGranted
+                                                    : formikQuantity;
+                                            const creditsPerUnit =
+                                                hardware[row.id]?.credits ?? 0;
+                                            // Get the condition from Formik; default to "Healthy" if not set.
+                                            const selectedCondition =
+                                                (props.values[
+                                                    `${row.id}-condition`
+                                                ] as string) || "Healthy";
+                                            // If the condition is "Broken" or "Lost", then row total is 0; otherwise, compute normally.
+                                            const rowTotal =
+                                                selectedCondition === "Broken" ||
+                                                selectedCondition === "Lost"
+                                                    ? 0
+                                                    : selectedQuantity * creditsPerUnit;
+                                            return sum + rowTotal;
+                                        },
+                                        0
+                                    );
+                                return (
+                                    <form onSubmit={props.handleSubmit}>
+                                        <div key={checkedOutOrder.id}>
+                                            <GeneralOrderTableTitle
+                                                orderId={checkedOutOrder.id}
+                                                orderStatus={checkedOutOrder.status}
+                                                createdTime={
+                                                    checkedOutOrder.createdTime
+                                                }
+                                                updatedTime={
+                                                    checkedOutOrder.updatedTime
+                                                }
+                                            />
+                                            <TableContainer
+                                                component={Paper}
+                                                elevation={2}
+                                                square={true}
                                             >
-                                                <TableHead>
-                                                    <TableRow>
-                                                        <TableCell
-                                                            className={
-                                                                styles.widthFixed
-                                                            }
-                                                        />
-                                                        <TableCell
-                                                            className={styles.width6}
-                                                        >
-                                                            Name
-                                                        </TableCell>
-                                                        <TableCell
-                                                            className={`${styles.width1} ${styles.noWrap}`}
-                                                        >
-                                                            Info
-                                                        </TableCell>
-                                                        <TableCell
-                                                            className={`${styles.width1} ${styles.noWrap}`}
-                                                        >
-                                                            💳 Credits
-                                                        </TableCell>
-                                                        <TableCell
-                                                            className={`${styles.width1} ${styles.noWrap}`}
-                                                        >
-                                                            Qty to return
-                                                        </TableCell>
-                                                        <TableCell
-                                                            className={`${styles.width6} ${styles.noWrap}`}
-                                                            align={"right"}
-                                                        >
-                                                            Qty remaining
-                                                        </TableCell>
-                                                        <TableCell
-                                                            className={`${styles.width1} ${styles.noWrap}`}
-                                                        >
-                                                            Condition
-                                                        </TableCell>
-                                                        <TableCell
-                                                            className={`${styles.width1} ${styles.noWrap}`}
-                                                        >
-                                                            <Checkbox
-                                                                color="primary"
-                                                                data-testid={`checkall-${checkedOutOrder.id}`}
-                                                                onChange={(e) => {
-                                                                    checkedOutOrder.hardwareInTableRow.forEach(
-                                                                        (row) => {
-                                                                            props.setFieldValue(
-                                                                                `${row.id}-checkbox`,
-                                                                                e.target
-                                                                                    .checked
-                                                                            );
-                                                                        }
-                                                                    );
-                                                                }}
+                                                <Table
+                                                    className={styles.table}
+                                                    size="small"
+                                                >
+                                                    <TableHead>
+                                                        <TableRow>
+                                                            <TableCell
+                                                                className={
+                                                                    styles.widthFixed
+                                                                }
                                                             />
-                                                        </TableCell>
-                                                    </TableRow>
-                                                </TableHead>
-                                                <TableBody>
-                                                    {checkedOutOrder.hardwareInTableRow.map(
-                                                        (row) => {
-                                                            // Use local state if available; otherwise, default to Formik's value.
-                                                            // Here we type-cast the value from Formik as a string.
-                                                            const selectedQuantity =
-                                                                selectedReturnQuantities[
-                                                                    row.id
-                                                                ] ??
-                                                                parseInt(
-                                                                    props.values[
-                                                                        `${row.id}-quantity`
-                                                                    ] as string,
-                                                                    10
-                                                                );
-                                                            const creditsPerUnit =
-                                                                hardware[row.id]
-                                                                    ?.credits ?? 0;
-                                                            const selectedCondition =
-                                                                (props.values[
-                                                                    `${row.id}-condition`
-                                                                ] as string) ||
-                                                                "Healthy";
-
-                                                            // Calculate total credits (set to 0 if condition is Broken or Lost)
-                                                            const totalCredits =
-                                                                selectedCondition ===
-                                                                    "Broken" ||
-                                                                selectedCondition ===
-                                                                    "Lost"
-                                                                    ? 0
-                                                                    : selectedQuantity *
-                                                                      creditsPerUnit;
-
-                                                            return (
-                                                                <TableRow
-                                                                    key={row.id}
-                                                                    data-testid={`table-${checkedOutOrder.id}-${row.id}`}
-                                                                >
-                                                                    <TableCell>
-                                                                        <img
-                                                                            className={
-                                                                                styles.itemImg
+                                                            <TableCell
+                                                                className={
+                                                                    styles.width6
+                                                                }
+                                                            >
+                                                                Name
+                                                            </TableCell>
+                                                            <TableCell
+                                                                className={`${styles.width1} ${styles.noWrap}`}
+                                                            >
+                                                                Info
+                                                            </TableCell>
+                                                            <TableCell
+                                                                className={`${styles.width1} ${styles.noWrap}`}
+                                                            >
+                                                                💳 Credits
+                                                            </TableCell>
+                                                            <TableCell
+                                                                className={`${styles.width1} ${styles.noWrap}`}
+                                                            >
+                                                                Qty to return
+                                                            </TableCell>
+                                                            <TableCell
+                                                                className={`${styles.width6} ${styles.noWrap}`}
+                                                                align={"right"}
+                                                            >
+                                                                Qty remaining
+                                                            </TableCell>
+                                                            <TableCell
+                                                                className={`${styles.width1} ${styles.noWrap}`}
+                                                            >
+                                                                Condition
+                                                            </TableCell>
+                                                            <TableCell
+                                                                className={`${styles.width1} ${styles.noWrap}`}
+                                                            >
+                                                                <Checkbox
+                                                                    color="primary"
+                                                                    data-testid={`checkall-${checkedOutOrder.id}`}
+                                                                    onChange={(e) => {
+                                                                        checkedOutOrder.hardwareInTableRow.forEach(
+                                                                            (row) => {
+                                                                                props.setFieldValue(
+                                                                                    `${row.id}-checkbox`,
+                                                                                    e
+                                                                                        .target
+                                                                                        .checked
+                                                                                );
                                                                             }
-                                                                            src={
-                                                                                hardware[
-                                                                                    row
-                                                                                        .id
-                                                                                ]
-                                                                                    ?.picture ??
-                                                                                hardware[
-                                                                                    row
-                                                                                        .id
-                                                                                ]
-                                                                                    ?.image_url ??
-                                                                                hardwareImagePlaceholder
-                                                                            }
-                                                                            alt={
+                                                                        );
+                                                                    }}
+                                                                />
+                                                            </TableCell>
+                                                        </TableRow>
+                                                    </TableHead>
+                                                    <TableBody>
+                                                        {checkedOutOrder.hardwareInTableRow.map(
+                                                            (row) => {
+                                                                // Use local state if available; otherwise, default to Formik's value.
+                                                                // Here we type-cast the value from Formik as a string.
+                                                                const selectedQuantity =
+                                                                    selectedReturnQuantities[
+                                                                        row.id
+                                                                    ] ??
+                                                                    parseInt(
+                                                                        props.values[
+                                                                            `${row.id}-quantity`
+                                                                        ] as string,
+                                                                        10
+                                                                    );
+                                                                const creditsPerUnit =
+                                                                    hardware[row.id]
+                                                                        ?.credits ?? 0;
+                                                                const selectedCondition =
+                                                                    (props.values[
+                                                                        `${row.id}-condition`
+                                                                    ] as string) ||
+                                                                    "Healthy";
+
+                                                                // Calculate total credits (set to 0 if condition is Broken or Lost)
+                                                                const totalCredits =
+                                                                    selectedCondition ===
+                                                                        "Broken" ||
+                                                                    selectedCondition ===
+                                                                        "Lost"
+                                                                        ? 0
+                                                                        : selectedQuantity *
+                                                                          creditsPerUnit;
+
+                                                                return (
+                                                                    <TableRow
+                                                                        key={row.id}
+                                                                        data-testid={`table-${checkedOutOrder.id}-${row.id}`}
+                                                                    >
+                                                                        <TableCell>
+                                                                            <img
+                                                                                className={
+                                                                                    styles.itemImg
+                                                                                }
+                                                                                src={
+                                                                                    hardware[
+                                                                                        row
+                                                                                            .id
+                                                                                    ]
+                                                                                        ?.picture ??
+                                                                                    hardware[
+                                                                                        row
+                                                                                            .id
+                                                                                    ]
+                                                                                        ?.image_url ??
+                                                                                    hardwareImagePlaceholder
+                                                                                }
+                                                                                alt={
+                                                                                    hardware[
+                                                                                        row
+                                                                                            .id
+                                                                                    ]
+                                                                                        ?.name
+                                                                                }
+                                                                            />
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                            {
                                                                                 hardware[
                                                                                     row
                                                                                         .id
                                                                                 ]?.name
                                                                             }
-                                                                        />
-                                                                    </TableCell>
-                                                                    <TableCell>
-                                                                        {
-                                                                            hardware[
-                                                                                row.id
-                                                                            ]?.name
-                                                                        }
-                                                                    </TableCell>
-                                                                    <TableCell>
-                                                                        <IconButton
-                                                                            color="inherit"
-                                                                            aria-label="Info"
-                                                                            data-testid="info-button"
-                                                                            onClick={() =>
-                                                                                openProductOverviewPanel(
-                                                                                    row.id
-                                                                                )
-                                                                            }
-                                                                        >
-                                                                            <Info />
-                                                                        </IconButton>
-                                                                    </TableCell>
-                                                                    <TableCell
-                                                                        style={{
-                                                                            textAlign:
-                                                                                "right",
-                                                                            fontWeight:
-                                                                                "bold",
-                                                                            color: "#28a745",
-                                                                        }}
-                                                                    >
-                                                                        {totalCredits}
-                                                                    </TableCell>
-                                                                    <TableCell>
-                                                                        <div
-                                                                            style={{
-                                                                                display:
-                                                                                    "flex",
-                                                                                alignItems:
-                                                                                    "end",
-                                                                            }}
-                                                                        >
-                                                                            <Link
-                                                                                underline="always"
-                                                                                color="textPrimary"
-                                                                                style={{
-                                                                                    marginRight:
-                                                                                        "15px",
-                                                                                }}
-                                                                                data-testid={`all-button`}
-                                                                                onClick={() => {
-                                                                                    // Update both Formik and local state with the full quantity
-                                                                                    props.setFieldValue(
-                                                                                        `${row.id}-quantity`,
-                                                                                        row.quantityGranted.toString()
-                                                                                    );
-                                                                                    setSelectedReturnQuantities(
-                                                                                        (
-                                                                                            prev
-                                                                                        ) => ({
-                                                                                            ...prev,
-                                                                                            [row.id]:
-                                                                                                row.quantityGranted,
-                                                                                        })
-                                                                                    );
-                                                                                }}
-                                                                            >
-                                                                                All
-                                                                            </Link>
-                                                                            <Select
-                                                                                value={
-                                                                                    selectedQuantity
-                                                                                }
-                                                                                onChange={(
-                                                                                    e
-                                                                                ) =>
-                                                                                    handleQuantityChange(
-                                                                                        row.id,
-                                                                                        e
-                                                                                            .target
-                                                                                            .value,
-                                                                                        props.setFieldValue
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                            <IconButton
+                                                                                color="inherit"
+                                                                                aria-label="Info"
+                                                                                data-testid="info-button"
+                                                                                onClick={() =>
+                                                                                    openProductOverviewPanel(
+                                                                                        row.id
                                                                                     )
                                                                                 }
-                                                                                label="Qty"
-                                                                                labelId="qtyLabel"
-                                                                                name={`${row.id}-quantity`}
-                                                                                id={`${row.id}-quantity`}
-                                                                                data-testid={`select`}
                                                                             >
-                                                                                {createDropdownList(
-                                                                                    row.quantityGranted
-                                                                                )}
-                                                                            </Select>
-                                                                        </div>
-                                                                    </TableCell>
-                                                                    <TableCell
-                                                                        align={"right"}
-                                                                    >
-                                                                        {
-                                                                            row.quantityGranted
-                                                                        }
-                                                                    </TableCell>
-                                                                    <TableCell>
-                                                                        <Select
-                                                                            value={
-                                                                                selectedCondition
+                                                                                <Info />
+                                                                            </IconButton>
+                                                                        </TableCell>
+                                                                        <TableCell
+                                                                            style={{
+                                                                                textAlign:
+                                                                                    "right",
+                                                                                fontWeight:
+                                                                                    "bold",
+                                                                                color: "#28a745",
+                                                                            }}
+                                                                        >
+                                                                            {
+                                                                                totalCredits
                                                                             }
-                                                                            onChange={
-                                                                                props.handleChange
-                                                                            }
-                                                                            label="Condition"
-                                                                            labelId="conditionLabel"
-                                                                            name={`${row.id}-condition`}
-                                                                            id={`${row.id}-condition`}
-                                                                            defaultValue={
-                                                                                "Healthy"
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                            <div
+                                                                                style={{
+                                                                                    display:
+                                                                                        "flex",
+                                                                                    alignItems:
+                                                                                        "end",
+                                                                                }}
+                                                                            >
+                                                                                <Link
+                                                                                    underline="always"
+                                                                                    color="textPrimary"
+                                                                                    style={{
+                                                                                        marginRight:
+                                                                                            "15px",
+                                                                                    }}
+                                                                                    data-testid={`all-button`}
+                                                                                    onClick={() => {
+                                                                                        // Update both Formik and local state with the full quantity
+                                                                                        props.setFieldValue(
+                                                                                            `${row.id}-quantity`,
+                                                                                            row.quantityGranted.toString()
+                                                                                        );
+                                                                                        setSelectedReturnQuantities(
+                                                                                            (
+                                                                                                prev
+                                                                                            ) => ({
+                                                                                                ...prev,
+                                                                                                [row.id]:
+                                                                                                    row.quantityGranted,
+                                                                                            })
+                                                                                        );
+                                                                                    }}
+                                                                                >
+                                                                                    All
+                                                                                </Link>
+                                                                                <Select
+                                                                                    value={
+                                                                                        selectedQuantity
+                                                                                    }
+                                                                                    onChange={(
+                                                                                        e
+                                                                                    ) =>
+                                                                                        handleQuantityChange(
+                                                                                            row.id,
+                                                                                            e
+                                                                                                .target
+                                                                                                .value,
+                                                                                            props.setFieldValue
+                                                                                        )
+                                                                                    }
+                                                                                    label="Qty"
+                                                                                    labelId="qtyLabel"
+                                                                                    name={`${row.id}-quantity`}
+                                                                                    id={`${row.id}-quantity`}
+                                                                                    data-testid={`select`}
+                                                                                >
+                                                                                    {createDropdownList(
+                                                                                        row.quantityGranted
+                                                                                    )}
+                                                                                </Select>
+                                                                            </div>
+                                                                        </TableCell>
+                                                                        <TableCell
+                                                                            align={
+                                                                                "right"
                                                                             }
                                                                         >
-                                                                            <MenuItem value="Healthy">
-                                                                                Healthy
-                                                                            </MenuItem>
-                                                                            <MenuItem value="Heavily Used">
-                                                                                Heavily
-                                                                                Used
-                                                                            </MenuItem>
-                                                                            <MenuItem value="Broken">
-                                                                                Broken
-                                                                            </MenuItem>
-                                                                            <MenuItem value="Lost">
-                                                                                Lost
-                                                                            </MenuItem>
-                                                                        </Select>
-                                                                    </TableCell>
-                                                                    <TableCell align="center">
-                                                                        <Checkbox
-                                                                            color="primary"
-                                                                            checked={
-                                                                                props
-                                                                                    .values[
-                                                                                    `${row.id}-checkbox`
-                                                                                ] ===
-                                                                                true
+                                                                            {
+                                                                                row.quantityGranted
                                                                             }
-                                                                            name={`${row.id}-checkbox`}
-                                                                            onChange={
-                                                                                props.handleChange
-                                                                            }
-                                                                            data-testid={`${row.id}-checkbox`}
-                                                                        />
-                                                                    </TableCell>
-                                                                </TableRow>
-                                                            );
-                                                        }
-                                                    )}
-                                                </TableBody>
-                                            </Table>
-                                        </TableContainer>
-                                        <Grid
-                                            container
-                                            justifyContent="flex-end"
-                                            spacing={1}
-                                            style={{ marginTop: "10px" }}
-                                        >
-                                            <Grid item style={{ marginTop: "5px" }}>
-                                                <Typography variant="body2">
-                                                    Note: participants will receive an
-                                                    email every time you change the
-                                                    status of their order.
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                            <Select
+                                                                                value={
+                                                                                    selectedCondition
+                                                                                }
+                                                                                onChange={
+                                                                                    props.handleChange
+                                                                                }
+                                                                                label="Condition"
+                                                                                labelId="conditionLabel"
+                                                                                name={`${row.id}-condition`}
+                                                                                id={`${row.id}-condition`}
+                                                                                defaultValue={
+                                                                                    "Healthy"
+                                                                                }
+                                                                            >
+                                                                                <MenuItem value="Healthy">
+                                                                                    Healthy
+                                                                                </MenuItem>
+                                                                                <MenuItem value="Heavily Used">
+                                                                                    Heavily
+                                                                                    Used
+                                                                                </MenuItem>
+                                                                                <MenuItem value="Broken">
+                                                                                    Broken
+                                                                                </MenuItem>
+                                                                                <MenuItem value="Lost">
+                                                                                    Lost
+                                                                                </MenuItem>
+                                                                            </Select>
+                                                                        </TableCell>
+                                                                        <TableCell align="center">
+                                                                            <Checkbox
+                                                                                color="primary"
+                                                                                checked={
+                                                                                    props
+                                                                                        .values[
+                                                                                        `${row.id}-checkbox`
+                                                                                    ] ===
+                                                                                    true
+                                                                                }
+                                                                                name={`${row.id}-checkbox`}
+                                                                                onChange={
+                                                                                    props.handleChange
+                                                                                }
+                                                                                data-testid={`${row.id}-checkbox`}
+                                                                            />
+                                                                        </TableCell>
+                                                                    </TableRow>
+                                                                );
+                                                            }
+                                                        )}
+                                                    </TableBody>
+                                                </Table>
+                                            </TableContainer>
+                                            {/* New Credit Subtotal Display */}
+                                            <Grid
+                                                container
+                                                justifyContent="flex-end"
+                                                style={{
+                                                    marginTop: "10px",
+                                                    marginRight: "10px",
+                                                }}
+                                            >
+                                                <Typography
+                                                    variant="subtitle1"
+                                                    color="textPrimary"
+                                                >
+                                                    Credits to Refund: 💳{" "}
+                                                    {orderTotalCredits}
                                                 </Typography>
                                             </Grid>
-                                            <Grid item>
-                                                <Button
-                                                    color="primary"
-                                                    variant="contained"
-                                                    type="submit"
-                                                    disableElevation
-                                                    disabled={
-                                                        returnIsLoading ||
-                                                        Object.keys(props.values).find(
-                                                            (key) =>
-                                                                key.includes(
-                                                                    "checkbox"
-                                                                ) &&
-                                                                props.values[key] ===
-                                                                    true
-                                                        ) === undefined
-                                                    }
-                                                    data-testid={`return-button-${checkedOutOrder.id}`}
-                                                >
-                                                    Return Items
-                                                </Button>
+                                            <Grid
+                                                container
+                                                justifyContent="flex-end"
+                                                spacing={1}
+                                                style={{ marginTop: "10px" }}
+                                            >
+                                                <Grid item style={{ marginTop: "5px" }}>
+                                                    <Typography variant="body2">
+                                                        Note: participants will receive
+                                                        an email every time you change
+                                                        the status of their order.
+                                                    </Typography>
+                                                </Grid>
+                                                <Grid item>
+                                                    <Button
+                                                        color="primary"
+                                                        variant="contained"
+                                                        type="submit"
+                                                        disableElevation
+                                                        disabled={
+                                                            returnIsLoading ||
+                                                            Object.keys(
+                                                                props.values
+                                                            ).find(
+                                                                (key) =>
+                                                                    key.includes(
+                                                                        "checkbox"
+                                                                    ) &&
+                                                                    props.values[
+                                                                        key
+                                                                    ] === true
+                                                            ) === undefined
+                                                        }
+                                                        data-testid={`return-button-${checkedOutOrder.id}`}
+                                                    >
+                                                        Return Items
+                                                    </Button>
+                                                </Grid>
                                             </Grid>
-                                        </Grid>
-                                    </div>
-                                </form>
-                            )}
+                                        </div>
+                                    </form>
+                                );
+                            }}
                         </Formik>
                     ))
                 ))}

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
@@ -12,13 +12,13 @@ import {
     TableHead,
     TableRow,
     Typography,
+    MenuItem,
+    Select,
 } from "@material-ui/core";
 import React, { useState } from "react";
 import Container from "@material-ui/core/Container";
 import styles from "components/general/OrderTables/OrderTables.module.scss";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
-import MenuItem from "@material-ui/core/MenuItem";
-import Select from "@material-ui/core/Select";
 import {
     GeneralOrderTableTitle,
     GeneralOrderTitle,
@@ -77,11 +77,24 @@ export const TeamCheckedOutOrderTable = () => {
     const toggleVisibility = () => {
         setVisibility(!visibility);
     };
+
+    // Local state for selected return quantities
     const [selectedReturnQuantities, setSelectedReturnQuantities] = useState<
         Record<number, number>
     >({});
 
-    const handleQuantityChange = (rowId: number, value: unknown) => {
+    const dispatch = useDispatch();
+    const openProductOverviewPanel = (hardwareId: number) => {
+        dispatch(getUpdatedHardwareDetails(hardwareId));
+        dispatch(openProductOverview());
+    };
+
+    // Update both local state and Formik's state on quantity change
+    const handleQuantityChange = (
+        rowId: number,
+        value: unknown,
+        setFieldValue: (field: string, value: any, shouldValidate?: boolean) => void
+    ) => {
         const parsedValue =
             typeof value === "string"
                 ? parseInt(value, 10) || 0
@@ -89,17 +102,16 @@ export const TeamCheckedOutOrderTable = () => {
                 ? value
                 : 0;
 
+        // Update local state
         setSelectedReturnQuantities((prev) => ({
             ...prev,
             [rowId]: parsedValue,
         }));
+
+        // Sync with Formik's state
+        setFieldValue(`${rowId}-quantity`, parsedValue.toString());
     };
 
-    const dispatch = useDispatch();
-    const openProductOverviewPanel = (hardwareId: number) => {
-        dispatch(getUpdatedHardwareDetails(hardwareId));
-        dispatch(openProductOverview());
-    };
     const handleReturnOrder = (values: FormikValues, orderId: number) => {
         try {
             // Find the order by ID
@@ -108,8 +120,8 @@ export const TeamCheckedOutOrderTable = () => {
                 throw new Error("Order not found.");
             }
 
-            // Convert formik values to correct format
-            const hardware: {
+            // Convert Formik values to the correct format
+            const hardwareReturnData: {
                 id: number;
                 quantity: number;
                 part_returned_health: string;
@@ -118,20 +130,20 @@ export const TeamCheckedOutOrderTable = () => {
             for (let i = 0; i < keys.length; i += 3) {
                 const id = parseInt(keys[i].split("-")[0]);
                 if (values[keys[i + 1]]) {
-                    hardware.push({
+                    hardwareReturnData.push({
                         id,
-                        quantity: values[keys[i]],
-                        part_returned_health: values[keys[i + 2]],
+                        quantity: parseInt(values[keys[i]] as string, 10),
+                        part_returned_health: values[keys[i + 2]] as string,
                     });
                 }
             }
 
-            dispatch(returnItems({ hardware, order: orderId }));
+            dispatch(returnItems({ hardware: hardwareReturnData, order: orderId }));
 
             // Check if all items in the order have been returned
             const allItemsReturned = checkedOutOrder.hardwareInTableRow.every((row) => {
                 const returnedQuantity =
-                    hardware.find((h) => h.id === row.id)?.quantity || 0;
+                    hardwareReturnData.find((h) => h.id === row.id)?.quantity || 0;
                 const remainingQty = (row.quantityGranted || 0) - returnedQuantity;
                 return remainingQty === 0;
             });
@@ -218,12 +230,6 @@ export const TeamCheckedOutOrderTable = () => {
                                                         >
                                                             💳 Credits
                                                         </TableCell>
-
-                                                        {/*<TableCell*/}
-                                                        {/*    className={`${styles.width1} ${styles.noWrap}`}*/}
-                                                        {/*>*/}
-                                                        {/*    Qty*/}
-                                                        {/*</TableCell>*/}
                                                         <TableCell
                                                             className={`${styles.width1} ${styles.noWrap}`}
                                                         >
@@ -264,19 +270,28 @@ export const TeamCheckedOutOrderTable = () => {
                                                 <TableBody>
                                                     {checkedOutOrder.hardwareInTableRow.map(
                                                         (row) => {
+                                                            // Use local state if available; otherwise, default to Formik's value.
+                                                            // Here we type-cast the value from Formik as a string.
                                                             const selectedQuantity =
                                                                 selectedReturnQuantities[
                                                                     row.id
-                                                                ] ?? 0;
+                                                                ] ??
+                                                                parseInt(
+                                                                    props.values[
+                                                                        `${row.id}-quantity`
+                                                                    ] as string,
+                                                                    10
+                                                                );
                                                             const creditsPerUnit =
                                                                 hardware[row.id]
                                                                     ?.credits ?? 0;
                                                             const selectedCondition =
-                                                                props.values[
+                                                                (props.values[
                                                                     `${row.id}-condition`
-                                                                ] ?? "Healthy";
+                                                                ] as string) ||
+                                                                "Healthy";
 
-                                                            // 🟢 Set total credits, but ensure it's 0 if "Broken" or "Lost"
+                                                            // Calculate total credits (set to 0 if condition is Broken or Lost)
                                                             const totalCredits =
                                                                 selectedCondition ===
                                                                     "Broken" ||
@@ -338,20 +353,13 @@ export const TeamCheckedOutOrderTable = () => {
                                                                             <Info />
                                                                         </IconButton>
                                                                     </TableCell>
-                                                                    {/* TODO: Add total quantity column */}
-                                                                    {/*<TableCell>*/}
-                                                                    {/*    {*/}
-                                                                    {/*        hardware[row.id]*/}
-                                                                    {/*            ?.quantity_available*/}
-                                                                    {/*    }*/}
-                                                                    {/*</TableCell>*/}
                                                                     <TableCell
                                                                         style={{
                                                                             textAlign:
                                                                                 "right",
                                                                             fontWeight:
                                                                                 "bold",
-                                                                            color: "#28a745", // 🟢 Green for gained credits
+                                                                            color: "#28a745",
                                                                         }}
                                                                     >
                                                                         {totalCredits}
@@ -374,9 +382,19 @@ export const TeamCheckedOutOrderTable = () => {
                                                                                 }}
                                                                                 data-testid={`all-button`}
                                                                                 onClick={() => {
+                                                                                    // Update both Formik and local state with the full quantity
                                                                                     props.setFieldValue(
                                                                                         `${row.id}-quantity`,
-                                                                                        row.quantityGranted
+                                                                                        row.quantityGranted.toString()
+                                                                                    );
+                                                                                    setSelectedReturnQuantities(
+                                                                                        (
+                                                                                            prev
+                                                                                        ) => ({
+                                                                                            ...prev,
+                                                                                            [row.id]:
+                                                                                                row.quantityGranted,
+                                                                                        })
                                                                                     );
                                                                                 }}
                                                                             >
@@ -393,8 +411,8 @@ export const TeamCheckedOutOrderTable = () => {
                                                                                         row.id,
                                                                                         e
                                                                                             .target
-                                                                                            .value ??
-                                                                                            0
+                                                                                            .value,
+                                                                                        props.setFieldValue
                                                                                     )
                                                                                 }
                                                                                 label="Qty"

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamCheckedOutOrderTable/TeamCheckedOutOrderTable.tsx
@@ -77,6 +77,24 @@ export const TeamCheckedOutOrderTable = () => {
     const toggleVisibility = () => {
         setVisibility(!visibility);
     };
+    const [selectedReturnQuantities, setSelectedReturnQuantities] = useState<
+        Record<number, number>
+    >({});
+
+    const handleQuantityChange = (rowId: number, value: unknown) => {
+        const parsedValue =
+            typeof value === "string"
+                ? parseInt(value, 10) || 0
+                : typeof value === "number"
+                ? value
+                : 0;
+
+        setSelectedReturnQuantities((prev) => ({
+            ...prev,
+            [rowId]: parsedValue,
+        }));
+    };
+
     const dispatch = useDispatch();
     const openProductOverviewPanel = (hardwareId: number) => {
         dispatch(getUpdatedHardwareDetails(hardwareId));
@@ -195,6 +213,12 @@ export const TeamCheckedOutOrderTable = () => {
                                                         >
                                                             Info
                                                         </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            💳 Credits
+                                                        </TableCell>
+
                                                         {/*<TableCell*/}
                                                         {/*    className={`${styles.width1} ${styles.noWrap}`}*/}
                                                         {/*>*/}
@@ -239,167 +263,210 @@ export const TeamCheckedOutOrderTable = () => {
                                                 </TableHead>
                                                 <TableBody>
                                                     {checkedOutOrder.hardwareInTableRow.map(
-                                                        (row) => (
-                                                            <TableRow
-                                                                key={row.id}
-                                                                data-testid={`table-${checkedOutOrder.id}-${row.id}`}
-                                                            >
-                                                                <TableCell>
-                                                                    <img
-                                                                        className={
-                                                                            styles.itemImg
-                                                                        }
-                                                                        src={
-                                                                            hardware[
-                                                                                row.id
-                                                                            ]
-                                                                                ?.picture ??
-                                                                            hardware[
-                                                                                row.id
-                                                                            ]
-                                                                                ?.image_url ??
-                                                                            hardwareImagePlaceholder
-                                                                        }
-                                                                        alt={
+                                                        (row) => {
+                                                            const selectedQuantity =
+                                                                selectedReturnQuantities[
+                                                                    row.id
+                                                                ] ?? 0;
+                                                            const creditsPerUnit =
+                                                                hardware[row.id]
+                                                                    ?.credits ?? 0;
+                                                            const selectedCondition =
+                                                                props.values[
+                                                                    `${row.id}-condition`
+                                                                ] ?? "Healthy";
+
+                                                            // 🟢 Set total credits, but ensure it's 0 if "Broken" or "Lost"
+                                                            const totalCredits =
+                                                                selectedCondition ===
+                                                                    "Broken" ||
+                                                                selectedCondition ===
+                                                                    "Lost"
+                                                                    ? 0
+                                                                    : selectedQuantity *
+                                                                      creditsPerUnit;
+
+                                                            return (
+                                                                <TableRow
+                                                                    key={row.id}
+                                                                    data-testid={`table-${checkedOutOrder.id}-${row.id}`}
+                                                                >
+                                                                    <TableCell>
+                                                                        <img
+                                                                            className={
+                                                                                styles.itemImg
+                                                                            }
+                                                                            src={
+                                                                                hardware[
+                                                                                    row
+                                                                                        .id
+                                                                                ]
+                                                                                    ?.picture ??
+                                                                                hardware[
+                                                                                    row
+                                                                                        .id
+                                                                                ]
+                                                                                    ?.image_url ??
+                                                                                hardwareImagePlaceholder
+                                                                            }
+                                                                            alt={
+                                                                                hardware[
+                                                                                    row
+                                                                                        .id
+                                                                                ]?.name
+                                                                            }
+                                                                        />
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        {
                                                                             hardware[
                                                                                 row.id
                                                                             ]?.name
                                                                         }
-                                                                    />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    {
-                                                                        hardware[row.id]
-                                                                            ?.name
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    <IconButton
-                                                                        color="inherit"
-                                                                        aria-label="Info"
-                                                                        data-testid="info-button"
-                                                                        onClick={() =>
-                                                                            openProductOverviewPanel(
-                                                                                row.id
-                                                                            )
-                                                                        }
-                                                                    >
-                                                                        <Info />
-                                                                    </IconButton>
-                                                                </TableCell>
-                                                                {/* TODO: Add total quantity column */}
-                                                                {/*<TableCell>*/}
-                                                                {/*    {*/}
-                                                                {/*        hardware[row.id]*/}
-                                                                {/*            ?.quantity_available*/}
-                                                                {/*    }*/}
-                                                                {/*</TableCell>*/}
-                                                                <TableCell>
-                                                                    <div
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        <IconButton
+                                                                            color="inherit"
+                                                                            aria-label="Info"
+                                                                            data-testid="info-button"
+                                                                            onClick={() =>
+                                                                                openProductOverviewPanel(
+                                                                                    row.id
+                                                                                )
+                                                                            }
+                                                                        >
+                                                                            <Info />
+                                                                        </IconButton>
+                                                                    </TableCell>
+                                                                    {/* TODO: Add total quantity column */}
+                                                                    {/*<TableCell>*/}
+                                                                    {/*    {*/}
+                                                                    {/*        hardware[row.id]*/}
+                                                                    {/*            ?.quantity_available*/}
+                                                                    {/*    }*/}
+                                                                    {/*</TableCell>*/}
+                                                                    <TableCell
                                                                         style={{
-                                                                            display:
-                                                                                "flex",
-                                                                            alignItems:
-                                                                                "end",
+                                                                            textAlign:
+                                                                                "right",
+                                                                            fontWeight:
+                                                                                "bold",
+                                                                            color: "#28a745", // 🟢 Green for gained credits
                                                                         }}
                                                                     >
-                                                                        <Link
-                                                                            underline="always"
-                                                                            color="textPrimary"
+                                                                        {totalCredits}
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        <div
                                                                             style={{
-                                                                                marginRight:
-                                                                                    "15px",
-                                                                            }}
-                                                                            data-testid={`all-button`}
-                                                                            onClick={() => {
-                                                                                props.setFieldValue(
-                                                                                    `${row.id}-quantity`,
-                                                                                    row.quantityGranted
-                                                                                );
+                                                                                display:
+                                                                                    "flex",
+                                                                                alignItems:
+                                                                                    "end",
                                                                             }}
                                                                         >
-                                                                            All
-                                                                        </Link>
+                                                                            <Link
+                                                                                underline="always"
+                                                                                color="textPrimary"
+                                                                                style={{
+                                                                                    marginRight:
+                                                                                        "15px",
+                                                                                }}
+                                                                                data-testid={`all-button`}
+                                                                                onClick={() => {
+                                                                                    props.setFieldValue(
+                                                                                        `${row.id}-quantity`,
+                                                                                        row.quantityGranted
+                                                                                    );
+                                                                                }}
+                                                                            >
+                                                                                All
+                                                                            </Link>
+                                                                            <Select
+                                                                                value={
+                                                                                    selectedQuantity
+                                                                                }
+                                                                                onChange={(
+                                                                                    e
+                                                                                ) =>
+                                                                                    handleQuantityChange(
+                                                                                        row.id,
+                                                                                        e
+                                                                                            .target
+                                                                                            .value ??
+                                                                                            0
+                                                                                    )
+                                                                                }
+                                                                                label="Qty"
+                                                                                labelId="qtyLabel"
+                                                                                name={`${row.id}-quantity`}
+                                                                                id={`${row.id}-quantity`}
+                                                                                data-testid={`select`}
+                                                                            >
+                                                                                {createDropdownList(
+                                                                                    row.quantityGranted
+                                                                                )}
+                                                                            </Select>
+                                                                        </div>
+                                                                    </TableCell>
+                                                                    <TableCell
+                                                                        align={"right"}
+                                                                    >
+                                                                        {
+                                                                            row.quantityGranted
+                                                                        }
+                                                                    </TableCell>
+                                                                    <TableCell>
                                                                         <Select
                                                                             value={
-                                                                                props
-                                                                                    .values[
-                                                                                    `${row.id}-quantity`
-                                                                                ]
+                                                                                selectedCondition
                                                                             }
                                                                             onChange={
                                                                                 props.handleChange
                                                                             }
-                                                                            label="Qty"
-                                                                            labelId="qtyLabel"
-                                                                            name={`${row.id}-quantity`}
-                                                                            id={`${row.id}-quantity`}
-                                                                            data-testid={`select`}
+                                                                            label="Condition"
+                                                                            labelId="conditionLabel"
+                                                                            name={`${row.id}-condition`}
+                                                                            id={`${row.id}-condition`}
+                                                                            defaultValue={
+                                                                                "Healthy"
+                                                                            }
                                                                         >
-                                                                            {createDropdownList(
-                                                                                row.quantityGranted
-                                                                            )}
+                                                                            <MenuItem value="Healthy">
+                                                                                Healthy
+                                                                            </MenuItem>
+                                                                            <MenuItem value="Heavily Used">
+                                                                                Heavily
+                                                                                Used
+                                                                            </MenuItem>
+                                                                            <MenuItem value="Broken">
+                                                                                Broken
+                                                                            </MenuItem>
+                                                                            <MenuItem value="Lost">
+                                                                                Lost
+                                                                            </MenuItem>
                                                                         </Select>
-                                                                    </div>
-                                                                </TableCell>
-                                                                <TableCell
-                                                                    align={"right"}
-                                                                >
-                                                                    {
-                                                                        row.quantityGranted
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    <Select
-                                                                        value={
-                                                                            props
-                                                                                .values[
-                                                                                `${row.id}-condition`
-                                                                            ]
-                                                                        }
-                                                                        onChange={
-                                                                            props.handleChange
-                                                                        }
-                                                                        label="Condition"
-                                                                        labelId="conditionLabel"
-                                                                        name={`${row.id}-condition`}
-                                                                        id={`${row.id}-condition`}
-                                                                        defaultValue={
-                                                                            "Healthy"
-                                                                        }
-                                                                    >
-                                                                        <MenuItem value="Healthy">
-                                                                            Healthy
-                                                                        </MenuItem>
-                                                                        <MenuItem value="Heavily Used">
-                                                                            Heavily Used
-                                                                        </MenuItem>
-                                                                        <MenuItem value="Broken">
-                                                                            Broken
-                                                                        </MenuItem>
-                                                                        <MenuItem value="Lost">
-                                                                            Lost
-                                                                        </MenuItem>
-                                                                    </Select>
-                                                                </TableCell>
-                                                                <TableCell align="center">
-                                                                    <Checkbox
-                                                                        color="primary"
-                                                                        checked={
-                                                                            props
-                                                                                .values[
-                                                                                `${row.id}-checkbox`
-                                                                            ] === true
-                                                                        }
-                                                                        name={`${row.id}-checkbox`}
-                                                                        onChange={
-                                                                            props.handleChange
-                                                                        }
-                                                                        data-testid={`${row.id}-checkbox`}
-                                                                    />
-                                                                </TableCell>
-                                                            </TableRow>
-                                                        )
+                                                                    </TableCell>
+                                                                    <TableCell align="center">
+                                                                        <Checkbox
+                                                                            color="primary"
+                                                                            checked={
+                                                                                props
+                                                                                    .values[
+                                                                                    `${row.id}-checkbox`
+                                                                                ] ===
+                                                                                true
+                                                                            }
+                                                                            name={`${row.id}-checkbox`}
+                                                                            onChange={
+                                                                                props.handleChange
+                                                                            }
+                                                                            data-testid={`${row.id}-checkbox`}
+                                                                        />
+                                                                    </TableCell>
+                                                                </TableRow>
+                                                            );
+                                                        }
                                                     )}
                                                 </TableBody>
                                             </Table>

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
@@ -140,400 +140,449 @@ export const TeamPendingOrderTable = () => {
                         }
                         key={pendingOrder.id}
                     >
-                        {(props) => (
-                            <form onSubmit={props.handleSubmit}>
-                                <div key={pendingOrder.id}>
-                                    <GeneralOrderTableTitle
-                                        orderId={pendingOrder.id}
-                                        orderStatus={pendingOrder.status}
-                                    />
-                                    <TableContainer
-                                        component={Paper}
-                                        elevation={2}
-                                        square={true}
-                                    >
-                                        <Table className={styles.table} size="small">
-                                            <TableHead>
-                                                <TableRow>
-                                                    <TableCell
-                                                        className={styles.widthFixed}
-                                                    />
-                                                    <TableCell
-                                                        className={styles.width6}
-                                                    >
-                                                        Name
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width1} ${styles.noWrap}`}
-                                                    >
-                                                        Model
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width1} ${styles.noWrap}`}
-                                                    >
-                                                        Manufacturer
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width1} ${styles.noWrap}`}
-                                                    >
-                                                        💳 Credits
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width1} ${styles.noWrap}`}
-                                                    >
-                                                        Qty requested
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width1} ${styles.noWrap}`}
-                                                    >
-                                                        Qty granted by system
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width6} ${styles.noWrap}`}
-                                                    >
-                                                        Qty granted
-                                                    </TableCell>
-                                                    <TableCell
-                                                        className={`${styles.width1} ${styles.noWrap}`}
-                                                    >
-                                                        {pendingOrder.status ===
-                                                            "Submitted" && (
-                                                            <Checkbox
-                                                                color="primary"
-                                                                data-testid={`checkall-${pendingOrder.id}`}
-                                                                onChange={(e) => {
-                                                                    pendingOrder.hardwareInTableRow.forEach(
-                                                                        (row) => {
-                                                                            props.setFieldValue(
-                                                                                `${row.id}-checkbox`,
-                                                                                e.target
-                                                                                    .checked
-                                                                            );
-                                                                        }
-                                                                    );
-                                                                }}
-                                                            />
-                                                        )}
-                                                    </TableCell>
-                                                </TableRow>
-                                            </TableHead>
-                                            <TableBody>
-                                                {pendingOrder.hardwareInTableRow.map(
-                                                    (row) => {
-                                                        const selectedQuantity =
-                                                            selectedQuantities[
-                                                                row.id
-                                                            ] ??
-                                                            row.quantityGrantedBySystem;
-                                                        const creditsPerUnit =
-                                                            hardware[row.id]?.credits ??
-                                                            0;
-                                                        const totalCredits =
-                                                            selectedQuantity *
-                                                            creditsPerUnit;
+                        {(props) => {
+                            // Calculate the order credit subtotal by iterating over each row.
+                            const orderTotalCredits =
+                                pendingOrder.hardwareInTableRow.reduce((sum, row) => {
+                                    // Use selected quantity if available; otherwise, use the default quantityGrantedBySystem.
+                                    const selectedQty =
+                                        selectedQuantities[row.id] !== undefined
+                                            ? selectedQuantities[row.id]
+                                            : row.quantityGrantedBySystem;
+                                    // Get the credits per unit for this hardware item.
+                                    const creditsPerUnit =
+                                        hardware[row.id]?.credits ?? 0;
+                                    return sum + selectedQty * creditsPerUnit;
+                                }, 0);
+                            return (
+                                <form onSubmit={props.handleSubmit}>
+                                    <div key={pendingOrder.id}>
+                                        <GeneralOrderTableTitle
+                                            orderId={pendingOrder.id}
+                                            orderStatus={pendingOrder.status}
+                                        />
+                                        <TableContainer
+                                            component={Paper}
+                                            elevation={2}
+                                            square={true}
+                                        >
+                                            <Table
+                                                className={styles.table}
+                                                size="small"
+                                            >
+                                                <TableHead>
+                                                    <TableRow>
+                                                        <TableCell
+                                                            className={
+                                                                styles.widthFixed
+                                                            }
+                                                        />
+                                                        <TableCell
+                                                            className={styles.width6}
+                                                        >
+                                                            Name
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            Model
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            Manufacturer
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            💳 Credits
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            Qty requested
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            Qty granted by system
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width6} ${styles.noWrap}`}
+                                                        >
+                                                            Qty granted
+                                                        </TableCell>
+                                                        <TableCell
+                                                            className={`${styles.width1} ${styles.noWrap}`}
+                                                        >
+                                                            {pendingOrder.status ===
+                                                                "Submitted" && (
+                                                                <Checkbox
+                                                                    color="primary"
+                                                                    data-testid={`checkall-${pendingOrder.id}`}
+                                                                    onChange={(e) => {
+                                                                        pendingOrder.hardwareInTableRow.forEach(
+                                                                            (row) => {
+                                                                                props.setFieldValue(
+                                                                                    `${row.id}-checkbox`,
+                                                                                    e
+                                                                                        .target
+                                                                                        .checked
+                                                                                );
+                                                                            }
+                                                                        );
+                                                                    }}
+                                                                />
+                                                            )}
+                                                        </TableCell>
+                                                    </TableRow>
+                                                </TableHead>
+                                                <TableBody>
+                                                    {pendingOrder.hardwareInTableRow.map(
+                                                        (row) => {
+                                                            const selectedQuantity =
+                                                                selectedQuantities[
+                                                                    row.id
+                                                                ] ??
+                                                                row.quantityGrantedBySystem;
+                                                            const creditsPerUnit =
+                                                                hardware[row.id]
+                                                                    ?.credits ?? 0;
+                                                            const totalCredits =
+                                                                selectedQuantity *
+                                                                creditsPerUnit;
 
-                                                        return (
-                                                            <TableRow
-                                                                key={row.id}
-                                                                data-testid={`table-${pendingOrder.id}-${row.id}`}
-                                                            >
-                                                                <TableCell>
-                                                                    <img
-                                                                        className={
-                                                                            styles.itemImg
-                                                                        }
-                                                                        src={
-                                                                            hardware[
-                                                                                row.id
-                                                                            ]
-                                                                                ?.picture ??
-                                                                            hardware[
-                                                                                row.id
-                                                                            ]
-                                                                                ?.image_url ??
-                                                                            hardwareImagePlaceholder
-                                                                        }
-                                                                        alt={
+                                                            return (
+                                                                <TableRow
+                                                                    key={row.id}
+                                                                    data-testid={`table-${pendingOrder.id}-${row.id}`}
+                                                                >
+                                                                    <TableCell>
+                                                                        <img
+                                                                            className={
+                                                                                styles.itemImg
+                                                                            }
+                                                                            src={
+                                                                                hardware[
+                                                                                    row
+                                                                                        .id
+                                                                                ]
+                                                                                    ?.picture ??
+                                                                                hardware[
+                                                                                    row
+                                                                                        .id
+                                                                                ]
+                                                                                    ?.image_url ??
+                                                                                hardwareImagePlaceholder
+                                                                            }
+                                                                            alt={
+                                                                                hardware[
+                                                                                    row
+                                                                                        .id
+                                                                                ]?.name
+                                                                            }
+                                                                        />
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        {
                                                                             hardware[
                                                                                 row.id
                                                                             ]?.name
                                                                         }
-                                                                    />
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    {
-                                                                        hardware[row.id]
-                                                                            ?.name
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    {
-                                                                        hardware[row.id]
-                                                                            ?.model_number
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    {
-                                                                        hardware[row.id]
-                                                                            ?.manufacturer
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell
-                                                                    style={{
-                                                                        textAlign:
-                                                                            "right",
-                                                                        color: "#5a6f94",
-                                                                    }}
-                                                                >
-                                                                    {totalCredits}
-                                                                </TableCell>
-                                                                <TableCell
-                                                                    style={{
-                                                                        textAlign:
-                                                                            "right",
-                                                                    }}
-                                                                >
-                                                                    {
-                                                                        row.quantityRequested
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell
-                                                                    style={{
-                                                                        textAlign:
-                                                                            "right",
-                                                                    }}
-                                                                >
-                                                                    {
-                                                                        row.quantityGrantedBySystem
-                                                                    }
-                                                                </TableCell>
-                                                                <TableCell>
-                                                                    {pendingOrder.status ===
-                                                                        "Submitted" && (
-                                                                        <div
-                                                                            style={{
-                                                                                display:
-                                                                                    "flex",
-                                                                                alignItems:
-                                                                                    "end",
-                                                                            }}
-                                                                        >
-                                                                            <Link
-                                                                                underline="always"
-                                                                                color="textPrimary"
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        {
+                                                                            hardware[
+                                                                                row.id
+                                                                            ]
+                                                                                ?.model_number
+                                                                        }
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        {
+                                                                            hardware[
+                                                                                row.id
+                                                                            ]
+                                                                                ?.manufacturer
+                                                                        }
+                                                                    </TableCell>
+                                                                    <TableCell
+                                                                        style={{
+                                                                            textAlign:
+                                                                                "right",
+                                                                            color: "#5a6f94",
+                                                                        }}
+                                                                    >
+                                                                        {totalCredits}
+                                                                    </TableCell>
+                                                                    <TableCell
+                                                                        style={{
+                                                                            textAlign:
+                                                                                "right",
+                                                                        }}
+                                                                    >
+                                                                        {
+                                                                            row.quantityRequested
+                                                                        }
+                                                                    </TableCell>
+                                                                    <TableCell
+                                                                        style={{
+                                                                            textAlign:
+                                                                                "right",
+                                                                        }}
+                                                                    >
+                                                                        {
+                                                                            row.quantityGrantedBySystem
+                                                                        }
+                                                                    </TableCell>
+                                                                    <TableCell>
+                                                                        {pendingOrder.status ===
+                                                                            "Submitted" && (
+                                                                            <div
                                                                                 style={{
-                                                                                    marginRight:
-                                                                                        "15px",
-                                                                                }}
-                                                                                data-testid={`all-button`}
-                                                                                onClick={() => {
-                                                                                    props.setFieldValue(
-                                                                                        `${row.id}-quantity`,
-                                                                                        row.quantityGrantedBySystem
-                                                                                    );
-                                                                                    handleQuantityChange(
-                                                                                        row.id,
-                                                                                        row.quantityGrantedBySystem
-                                                                                    );
+                                                                                    display:
+                                                                                        "flex",
+                                                                                    alignItems:
+                                                                                        "end",
                                                                                 }}
                                                                             >
-                                                                                All
-                                                                            </Link>
-                                                                            <Select
-                                                                                value={
-                                                                                    selectedQuantity
+                                                                                <Link
+                                                                                    underline="always"
+                                                                                    color="textPrimary"
+                                                                                    style={{
+                                                                                        marginRight:
+                                                                                            "15px",
+                                                                                    }}
+                                                                                    data-testid={`all-button`}
+                                                                                    onClick={() => {
+                                                                                        props.setFieldValue(
+                                                                                            `${row.id}-quantity`,
+                                                                                            row.quantityGrantedBySystem
+                                                                                        );
+                                                                                        handleQuantityChange(
+                                                                                            row.id,
+                                                                                            row.quantityGrantedBySystem
+                                                                                        );
+                                                                                    }}
+                                                                                >
+                                                                                    All
+                                                                                </Link>
+                                                                                <Select
+                                                                                    value={
+                                                                                        selectedQuantity
+                                                                                    }
+                                                                                    onChange={(
+                                                                                        e
+                                                                                    ) => {
+                                                                                        props.handleChange(
+                                                                                            e
+                                                                                        );
+                                                                                        handleQuantityChange(
+                                                                                            row.id,
+                                                                                            e
+                                                                                                .target
+                                                                                                .value ??
+                                                                                                0
+                                                                                        );
+                                                                                    }}
+                                                                                    label="Qty"
+                                                                                    labelId="qtyLabel"
+                                                                                    name={`${row.id}-quantity`}
+                                                                                    id={`${row.id}-quantity`}
+                                                                                    data-testid={`select`}
+                                                                                >
+                                                                                    {createDropdownList(
+                                                                                        row.quantityGrantedBySystem
+                                                                                    )}
+                                                                                </Select>
+                                                                            </div>
+                                                                        )}
+                                                                        {pendingOrder.status ===
+                                                                            "Ready for Pickup" && (
+                                                                            <p
+                                                                                style={{
+                                                                                    textAlign:
+                                                                                        "center",
+                                                                                    ...(row.quantityGranted <
+                                                                                        row.quantityGrantedBySystem && {
+                                                                                        fontWeight:
+                                                                                            "bold",
+                                                                                        backgroundColor:
+                                                                                            "#c1edc1",
+                                                                                    }),
+                                                                                }}
+                                                                            >
+                                                                                {
+                                                                                    row.quantityGranted
                                                                                 }
-                                                                                onChange={(
-                                                                                    e
-                                                                                ) => {
-                                                                                    props.handleChange(
-                                                                                        e
-                                                                                    );
-                                                                                    handleQuantityChange(
-                                                                                        row.id,
-                                                                                        e
-                                                                                            .target
-                                                                                            .value ??
-                                                                                            0
-                                                                                    );
-                                                                                }}
-                                                                                label="Qty"
-                                                                                labelId="qtyLabel"
-                                                                                name={`${row.id}-quantity`}
-                                                                                id={`${row.id}-quantity`}
-                                                                                data-testid={`select`}
-                                                                            >
-                                                                                {createDropdownList(
-                                                                                    row.quantityGrantedBySystem
-                                                                                )}
-                                                                            </Select>
-                                                                        </div>
-                                                                    )}
-                                                                    {pendingOrder.status ===
-                                                                        "Ready for Pickup" && (
-                                                                        <p
-                                                                            style={{
-                                                                                textAlign:
-                                                                                    "center",
-                                                                                ...(row.quantityGranted <
-                                                                                    row.quantityGrantedBySystem && {
-                                                                                    fontWeight:
-                                                                                        "bold",
-                                                                                    backgroundColor:
-                                                                                        "#c1edc1",
-                                                                                }),
-                                                                            }}
-                                                                        >
-                                                                            {
-                                                                                row.quantityGranted
-                                                                            }
-                                                                        </p>
-                                                                    )}
-                                                                </TableCell>
-                                                                <TableCell align="center">
-                                                                    {pendingOrder.status ===
-                                                                        "Submitted" && (
-                                                                        <Checkbox
-                                                                            color="primary"
-                                                                            checked={
-                                                                                props
-                                                                                    .values[
-                                                                                    `${row.id}-checkbox`
-                                                                                ] ===
-                                                                                true
-                                                                            }
-                                                                            name={`${row.id}-checkbox`}
-                                                                            onChange={
-                                                                                props.handleChange
-                                                                            }
-                                                                            data-testid={`${row.id}-checkbox`}
-                                                                        />
-                                                                    )}
-                                                                </TableCell>
-                                                            </TableRow>
-                                                        );
-                                                    }
-                                                )}
-                                            </TableBody>
-                                        </Table>
-                                    </TableContainer>
-                                    <Grid
-                                        container
-                                        justifyContent="flex-end"
-                                        spacing={1}
-                                        style={{ marginTop: "10px" }}
-                                    >
-                                        <Grid item style={{ marginTop: "5px" }}>
-                                            <Typography variant="body2">
-                                                Note: participants will receive an email
-                                                every time you change the status of
-                                                their order.
+                                                                            </p>
+                                                                        )}
+                                                                    </TableCell>
+                                                                    <TableCell align="center">
+                                                                        {pendingOrder.status ===
+                                                                            "Submitted" && (
+                                                                            <Checkbox
+                                                                                color="primary"
+                                                                                checked={
+                                                                                    props
+                                                                                        .values[
+                                                                                        `${row.id}-checkbox`
+                                                                                    ] ===
+                                                                                    true
+                                                                                }
+                                                                                name={`${row.id}-checkbox`}
+                                                                                onChange={
+                                                                                    props.handleChange
+                                                                                }
+                                                                                data-testid={`${row.id}-checkbox`}
+                                                                            />
+                                                                        )}
+                                                                    </TableCell>
+                                                                </TableRow>
+                                                            );
+                                                        }
+                                                    )}
+                                                </TableBody>
+                                            </Table>
+                                        </TableContainer>
+                                        {/* New Credit Subtotal Display */}
+                                        <Grid
+                                            container
+                                            justifyContent="flex-end"
+                                            style={{
+                                                marginTop: "10px",
+                                                marginRight: "10px",
+                                            }}
+                                        >
+                                            <Typography
+                                                variant="subtitle1"
+                                                color="textPrimary"
+                                            >
+                                                Credits Used: 💳 {orderTotalCredits}
                                             </Typography>
                                         </Grid>
-                                        {pendingOrder.status === "Submitted" && (
-                                            <Grid item>
-                                                <Button
-                                                    onClick={() =>
-                                                        updateOrder(
-                                                            pendingOrder.id,
-                                                            "Cancelled"
-                                                        )
-                                                    }
-                                                    disabled={isLoading}
-                                                    color="secondary"
-                                                    variant="text"
-                                                    disableElevation
-                                                >
-                                                    Reject Order
-                                                </Button>
+                                        <Grid
+                                            container
+                                            justifyContent="flex-end"
+                                            spacing={1}
+                                            style={{ marginTop: "10px" }}
+                                        >
+                                            <Grid item style={{ marginTop: "5px" }}>
+                                                <Typography variant="body2">
+                                                    Note: participants will receive an
+                                                    email every time you change the
+                                                    status of their order.
+                                                </Typography>
                                             </Grid>
-                                        )}
-                                        {pendingOrder.status === "Ready for Pickup" && (
-                                            <Grid item>
-                                                <Button
-                                                    onClick={() =>
-                                                        updateOrder(
-                                                            pendingOrder.id,
-                                                            "Submitted"
-                                                        )
-                                                    }
-                                                    disabled={isLoading}
-                                                    color="secondary"
-                                                    variant="text"
-                                                    disableElevation
-                                                >
-                                                    Edit Order
-                                                </Button>
-                                            </Grid>
-                                        )}
-                                        {pendingOrder.status === "Submitted" && (
-                                            <Grid item>
-                                                <Button
-                                                    color="primary"
-                                                    variant="contained"
-                                                    type="submit"
-                                                    disableElevation
-                                                    data-testid={`complete-button-${pendingOrder.id}`}
-                                                    disabled={
-                                                        isLoading ||
-                                                        // Check if all quantity fields are zero
-                                                        Object.keys(props.values)
-                                                            .filter((key) =>
-                                                                key.endsWith(
-                                                                    "-quantity"
-                                                                )
+                                            {pendingOrder.status === "Submitted" && (
+                                                <Grid item>
+                                                    <Button
+                                                        onClick={() =>
+                                                            updateOrder(
+                                                                pendingOrder.id,
+                                                                "Cancelled"
                                                             )
-                                                            .every(
-                                                                (key) =>
-                                                                    props.values[
-                                                                        key
-                                                                    ] === "0"
-                                                            ) ||
-                                                        // Check if no checkbox is selected
-                                                        Object.keys(props.values)
-                                                            .filter((key) =>
-                                                                key.endsWith(
-                                                                    "-checkbox"
-                                                                )
+                                                        }
+                                                        disabled={isLoading}
+                                                        color="secondary"
+                                                        variant="text"
+                                                        disableElevation
+                                                    >
+                                                        Reject Order
+                                                    </Button>
+                                                </Grid>
+                                            )}
+                                            {pendingOrder.status ===
+                                                "Ready for Pickup" && (
+                                                <Grid item>
+                                                    <Button
+                                                        onClick={() =>
+                                                            updateOrder(
+                                                                pendingOrder.id,
+                                                                "Submitted"
                                                             )
-                                                            .every(
-                                                                (key) =>
-                                                                    !props.values[key]
-                                                            )
-                                                    }
-                                                >
-                                                    Complete Order
-                                                </Button>
-                                            </Grid>
-                                        )}
-                                        {pendingOrder.status === "Ready for Pickup" && (
-                                            <Grid item>
-                                                <Tooltip
-                                                    title="Ensure that you've collected a piece of ID before the team picks up the order"
-                                                    placement="top"
-                                                >
-                                                    <span>
-                                                        <Button
-                                                            color="secondary"
-                                                            variant="contained"
-                                                            disableElevation
-                                                            onClick={() =>
-                                                                updateOrder(
-                                                                    pendingOrder.id,
-                                                                    "Picked Up"
+                                                        }
+                                                        disabled={isLoading}
+                                                        color="secondary"
+                                                        variant="text"
+                                                        disableElevation
+                                                    >
+                                                        Edit Order
+                                                    </Button>
+                                                </Grid>
+                                            )}
+                                            {pendingOrder.status === "Submitted" && (
+                                                <Grid item>
+                                                    <Button
+                                                        color="primary"
+                                                        variant="contained"
+                                                        type="submit"
+                                                        disableElevation
+                                                        data-testid={`complete-button-${pendingOrder.id}`}
+                                                        disabled={
+                                                            isLoading ||
+                                                            // Check if all quantity fields are zero
+                                                            Object.keys(props.values)
+                                                                .filter((key) =>
+                                                                    key.endsWith(
+                                                                        "-quantity"
+                                                                    )
                                                                 )
-                                                            }
-                                                        >
-                                                            Picked Up
-                                                        </Button>
-                                                    </span>
-                                                </Tooltip>
-                                            </Grid>
-                                        )}
-                                    </Grid>
-                                </div>
-                            </form>
-                        )}
+                                                                .every(
+                                                                    (key) =>
+                                                                        props.values[
+                                                                            key
+                                                                        ] === "0"
+                                                                ) ||
+                                                            // Check if no checkbox is selected
+                                                            Object.keys(props.values)
+                                                                .filter((key) =>
+                                                                    key.endsWith(
+                                                                        "-checkbox"
+                                                                    )
+                                                                )
+                                                                .every(
+                                                                    (key) =>
+                                                                        !props.values[
+                                                                            key
+                                                                        ]
+                                                                )
+                                                        }
+                                                    >
+                                                        Complete Order
+                                                    </Button>
+                                                </Grid>
+                                            )}
+                                            {pendingOrder.status ===
+                                                "Ready for Pickup" && (
+                                                <Grid item>
+                                                    <Tooltip
+                                                        title="Ensure that you've collected a piece of ID before the team picks up the order"
+                                                        placement="top"
+                                                    >
+                                                        <span>
+                                                            <Button
+                                                                color="secondary"
+                                                                variant="contained"
+                                                                disableElevation
+                                                                onClick={() =>
+                                                                    updateOrder(
+                                                                        pendingOrder.id,
+                                                                        "Picked Up"
+                                                                    )
+                                                                }
+                                                            >
+                                                                Picked Up
+                                                            </Button>
+                                                        </span>
+                                                    </Tooltip>
+                                                </Grid>
+                                            )}
+                                        </Grid>
+                                    </div>
+                                </form>
+                            );
+                        }}
                     </Formik>
                 ))}
         </Container>

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
@@ -66,6 +66,24 @@ export const TeamPendingOrderTable = () => {
     const hardware = useSelector(hardwareSelectors.selectEntities);
     const isLoading = useSelector(isLoadingSelector);
     const [visibility, setVisibility] = useState(true);
+    const [selectedQuantities, setSelectedQuantities] = useState<
+        Record<number, number>
+    >({});
+
+    const handleQuantityChange = (rowId: number, value: unknown) => {
+        const parsedValue =
+            typeof value === "string"
+                ? parseInt(value, 10) || 0
+                : typeof value === "number"
+                ? value
+                : 0;
+
+        setSelectedQuantities((prev: Record<number, number>) => ({
+            ...prev,
+            [rowId]: parsedValue,
+        }));
+    };
+
     const toggleVisibility = () => {
         setVisibility(!visibility);
     };
@@ -158,6 +176,11 @@ export const TeamPendingOrderTable = () => {
                                                     <TableCell
                                                         className={`${styles.width1} ${styles.noWrap}`}
                                                     >
+                                                        💳 Credits
+                                                    </TableCell>
+                                                    <TableCell
+                                                        className={`${styles.width1} ${styles.noWrap}`}
+                                                    >
                                                         Qty requested
                                                     </TableCell>
                                                     <TableCell
@@ -196,152 +219,200 @@ export const TeamPendingOrderTable = () => {
                                             </TableHead>
                                             <TableBody>
                                                 {pendingOrder.hardwareInTableRow.map(
-                                                    (row) => (
-                                                        <TableRow
-                                                            key={row.id}
-                                                            data-testid={`table-${pendingOrder.id}-${row.id}`}
-                                                        >
-                                                            <TableCell>
-                                                                <img
-                                                                    className={
-                                                                        styles.itemImg
-                                                                    }
-                                                                    src={
-                                                                        hardware[row.id]
-                                                                            ?.picture ??
-                                                                        hardware[row.id]
-                                                                            ?.image_url ??
-                                                                        hardwareImagePlaceholder
-                                                                    }
-                                                                    alt={
+                                                    (row) => {
+                                                        const selectedQuantity =
+                                                            selectedQuantities[
+                                                                row.id
+                                                            ] ??
+                                                            row.quantityGrantedBySystem;
+                                                        const creditsPerUnit =
+                                                            hardware[row.id]?.credits ??
+                                                            0;
+                                                        const totalCredits =
+                                                            selectedQuantity *
+                                                            creditsPerUnit;
+
+                                                        return (
+                                                            <TableRow
+                                                                key={row.id}
+                                                                data-testid={`table-${pendingOrder.id}-${row.id}`}
+                                                            >
+                                                                <TableCell>
+                                                                    <img
+                                                                        className={
+                                                                            styles.itemImg
+                                                                        }
+                                                                        src={
+                                                                            hardware[
+                                                                                row.id
+                                                                            ]
+                                                                                ?.picture ??
+                                                                            hardware[
+                                                                                row.id
+                                                                            ]
+                                                                                ?.image_url ??
+                                                                            hardwareImagePlaceholder
+                                                                        }
+                                                                        alt={
+                                                                            hardware[
+                                                                                row.id
+                                                                            ]?.name
+                                                                        }
+                                                                    />
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                    {
                                                                         hardware[row.id]
                                                                             ?.name
                                                                     }
-                                                                />
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {hardware[row.id]?.name}
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {
-                                                                    hardware[row.id]
-                                                                        ?.model_number
-                                                                }
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {
-                                                                    hardware[row.id]
-                                                                        ?.manufacturer
-                                                                }
-                                                            </TableCell>
-                                                            <TableCell
-                                                                style={{
-                                                                    textAlign: "right",
-                                                                }}
-                                                            >
-                                                                {row.quantityRequested}
-                                                            </TableCell>
-                                                            <TableCell
-                                                                style={{
-                                                                    textAlign: "right",
-                                                                }}
-                                                            >
-                                                                {
-                                                                    row.quantityGrantedBySystem
-                                                                }
-                                                            </TableCell>
-                                                            <TableCell>
-                                                                {pendingOrder.status ===
-                                                                    "Submitted" && (
-                                                                    <div
-                                                                        style={{
-                                                                            display:
-                                                                                "flex",
-                                                                            alignItems:
-                                                                                "end",
-                                                                        }}
-                                                                    >
-                                                                        <Link
-                                                                            underline="always"
-                                                                            color="textPrimary"
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                    {
+                                                                        hardware[row.id]
+                                                                            ?.model_number
+                                                                    }
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                    {
+                                                                        hardware[row.id]
+                                                                            ?.manufacturer
+                                                                    }
+                                                                </TableCell>
+                                                                <TableCell
+                                                                    style={{
+                                                                        textAlign:
+                                                                            "right",
+                                                                        color: "#5a6f94",
+                                                                    }}
+                                                                >
+                                                                    {totalCredits}
+                                                                </TableCell>
+                                                                <TableCell
+                                                                    style={{
+                                                                        textAlign:
+                                                                            "right",
+                                                                    }}
+                                                                >
+                                                                    {
+                                                                        row.quantityRequested
+                                                                    }
+                                                                </TableCell>
+                                                                <TableCell
+                                                                    style={{
+                                                                        textAlign:
+                                                                            "right",
+                                                                    }}
+                                                                >
+                                                                    {
+                                                                        row.quantityGrantedBySystem
+                                                                    }
+                                                                </TableCell>
+                                                                <TableCell>
+                                                                    {pendingOrder.status ===
+                                                                        "Submitted" && (
+                                                                        <div
                                                                             style={{
-                                                                                marginRight:
-                                                                                    "15px",
-                                                                            }}
-                                                                            data-testid={`all-button`}
-                                                                            onClick={() => {
-                                                                                props.setFieldValue(
-                                                                                    `${row.id}-quantity`,
-                                                                                    row.quantityGrantedBySystem
-                                                                                );
+                                                                                display:
+                                                                                    "flex",
+                                                                                alignItems:
+                                                                                    "end",
                                                                             }}
                                                                         >
-                                                                            All
-                                                                        </Link>
-                                                                        <Select
-                                                                            value={
+                                                                            <Link
+                                                                                underline="always"
+                                                                                color="textPrimary"
+                                                                                style={{
+                                                                                    marginRight:
+                                                                                        "15px",
+                                                                                }}
+                                                                                data-testid={`all-button`}
+                                                                                onClick={() => {
+                                                                                    props.setFieldValue(
+                                                                                        `${row.id}-quantity`,
+                                                                                        row.quantityGrantedBySystem
+                                                                                    );
+                                                                                    handleQuantityChange(
+                                                                                        row.id,
+                                                                                        row.quantityGrantedBySystem
+                                                                                    );
+                                                                                }}
+                                                                            >
+                                                                                All
+                                                                            </Link>
+                                                                            <Select
+                                                                                value={
+                                                                                    selectedQuantity
+                                                                                }
+                                                                                onChange={(
+                                                                                    e
+                                                                                ) => {
+                                                                                    props.handleChange(
+                                                                                        e
+                                                                                    );
+                                                                                    handleQuantityChange(
+                                                                                        row.id,
+                                                                                        e
+                                                                                            .target
+                                                                                            .value ??
+                                                                                            0
+                                                                                    );
+                                                                                }}
+                                                                                label="Qty"
+                                                                                labelId="qtyLabel"
+                                                                                name={`${row.id}-quantity`}
+                                                                                id={`${row.id}-quantity`}
+                                                                                data-testid={`select`}
+                                                                            >
+                                                                                {createDropdownList(
+                                                                                    row.quantityGrantedBySystem
+                                                                                )}
+                                                                            </Select>
+                                                                        </div>
+                                                                    )}
+                                                                    {pendingOrder.status ===
+                                                                        "Ready for Pickup" && (
+                                                                        <p
+                                                                            style={{
+                                                                                textAlign:
+                                                                                    "center",
+                                                                                ...(row.quantityGranted <
+                                                                                    row.quantityGrantedBySystem && {
+                                                                                    fontWeight:
+                                                                                        "bold",
+                                                                                    backgroundColor:
+                                                                                        "#c1edc1",
+                                                                                }),
+                                                                            }}
+                                                                        >
+                                                                            {
+                                                                                row.quantityGranted
+                                                                            }
+                                                                        </p>
+                                                                    )}
+                                                                </TableCell>
+                                                                <TableCell align="center">
+                                                                    {pendingOrder.status ===
+                                                                        "Submitted" && (
+                                                                        <Checkbox
+                                                                            color="primary"
+                                                                            checked={
                                                                                 props
                                                                                     .values[
-                                                                                    `${row.id}-quantity`
-                                                                                ]
+                                                                                    `${row.id}-checkbox`
+                                                                                ] ===
+                                                                                true
                                                                             }
+                                                                            name={`${row.id}-checkbox`}
                                                                             onChange={
                                                                                 props.handleChange
                                                                             }
-                                                                            label="Qty"
-                                                                            labelId="qtyLabel"
-                                                                            name={`${row.id}-quantity`}
-                                                                            id={`${row.id}-quantity`}
-                                                                            data-testid={`select`}
-                                                                        >
-                                                                            {createDropdownList(
-                                                                                row.quantityGrantedBySystem
-                                                                            )}
-                                                                        </Select>
-                                                                    </div>
-                                                                )}
-                                                                {pendingOrder.status ===
-                                                                    "Ready for Pickup" && (
-                                                                    <p
-                                                                        style={{
-                                                                            textAlign:
-                                                                                "center",
-                                                                            ...(row.quantityGranted <
-                                                                                row.quantityGrantedBySystem && {
-                                                                                fontWeight:
-                                                                                    "bold",
-                                                                                backgroundColor:
-                                                                                    "#c1edc1",
-                                                                            }),
-                                                                        }}
-                                                                    >
-                                                                        {
-                                                                            row.quantityGranted
-                                                                        }
-                                                                    </p>
-                                                                )}
-                                                            </TableCell>
-                                                            <TableCell align="center">
-                                                                {pendingOrder.status ===
-                                                                    "Submitted" && (
-                                                                    <Checkbox
-                                                                        color="primary"
-                                                                        checked={
-                                                                            props
-                                                                                .values[
-                                                                                `${row.id}-checkbox`
-                                                                            ] === true
-                                                                        }
-                                                                        name={`${row.id}-checkbox`}
-                                                                        onChange={
-                                                                            props.handleChange
-                                                                        }
-                                                                        data-testid={`${row.id}-checkbox`}
-                                                                    />
-                                                                )}
-                                                            </TableCell>
-                                                        </TableRow>
-                                                    )
+                                                                            data-testid={`${row.id}-checkbox`}
+                                                                        />
+                                                                    )}
+                                                                </TableCell>
+                                                            </TableRow>
+                                                        );
+                                                    }
                                                 )}
                                             </TableBody>
                                         </Table>

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
@@ -27,12 +27,14 @@ import {
 import { Formik, FormikValues } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 import {
+    getCreditsUsedSelector,
     isLoadingSelector,
     pendingOrdersSelector,
     UpdateOrderAttributes,
     updateOrderStatus,
 } from "slices/order/teamOrderSlice";
 import { hardwareSelectors } from "slices/hardware/hardwareSlice";
+import { teamStartingCreditsSelector } from "slices/event/teamDetailSlice";
 
 const createDropdownList = (number: number) => {
     let entry = [];
@@ -66,6 +68,10 @@ export const TeamPendingOrderTable = () => {
     const hardware = useSelector(hardwareSelectors.selectEntities);
     const isLoading = useSelector(isLoadingSelector);
     const [visibility, setVisibility] = useState(true);
+    const creditsAvailable = useSelector(teamStartingCreditsSelector);
+    const creditsUsed = useSelector(getCreditsUsedSelector);
+    const creditsRemaining = creditsAvailable ? creditsAvailable - creditsUsed : 0;
+
     const [selectedQuantities, setSelectedQuantities] = useState<
         Record<number, number>
     >({});
@@ -160,6 +166,7 @@ export const TeamPendingOrderTable = () => {
                                         <GeneralOrderTableTitle
                                             orderId={pendingOrder.id}
                                             orderStatus={pendingOrder.status}
+                                            overLimit={creditsRemaining < 0}
                                         />
                                         <TableContainer
                                             component={Paper}

--- a/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/teamDetail/TeamPendingOrderTable/TeamPendingOrderTable.tsx
@@ -476,14 +476,30 @@ export const TeamPendingOrderTable = () => {
                                                     data-testid={`complete-button-${pendingOrder.id}`}
                                                     disabled={
                                                         isLoading ||
-                                                        Object.keys(
-                                                            props.values
-                                                        ).findIndex(
-                                                            (key) =>
-                                                                key.includes(
-                                                                    "checkbox"
-                                                                ) && props.values[key]
-                                                        ) === -1
+                                                        // Check if all quantity fields are zero
+                                                        Object.keys(props.values)
+                                                            .filter((key) =>
+                                                                key.endsWith(
+                                                                    "-quantity"
+                                                                )
+                                                            )
+                                                            .every(
+                                                                (key) =>
+                                                                    props.values[
+                                                                        key
+                                                                    ] === "0"
+                                                            ) ||
+                                                        // Check if no checkbox is selected
+                                                        Object.keys(props.values)
+                                                            .filter((key) =>
+                                                                key.endsWith(
+                                                                    "-checkbox"
+                                                                )
+                                                            )
+                                                            .every(
+                                                                (key) =>
+                                                                    !props.values[key]
+                                                            )
                                                     }
                                                 >
                                                     Complete Order

--- a/hackathon_site/dashboard/frontend/src/constants.js
+++ b/hackathon_site/dashboard/frontend/src/constants.js
@@ -7,3 +7,4 @@ export const hardwareSignOutEndDate = new Date(2025, 1, 16, 11, 0);
 export const hssTestUserGroup = "HSS Test Users";
 export const serverUrl = "https://makeuoft.ca";
 export const minProjectDescriptionLength = 60;
+export const startingCredits = 300;

--- a/hackathon_site/dashboard/frontend/src/pages/TeamDetail/TeamDetail.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/TeamDetail/TeamDetail.tsx
@@ -12,6 +12,7 @@ import { AdminReturnedItemsTable } from "components/teamDetail/SimpleOrderTables
 import {
     errorSelector,
     getAdminTeamOrders,
+    getCreditsUsedSelector,
     hardwareInOrdersSelector,
 } from "slices/order/teamOrderSlice";
 
@@ -19,6 +20,7 @@ import { useDispatch, useSelector } from "react-redux";
 import {
     getTeamInfoData,
     teamInfoErrorSelector,
+    teamStartingCreditsSelector,
     updateParticipantIdErrorSelector,
 } from "slices/event/teamDetailSlice";
 import AlertBox from "components/general/AlertBox/AlertBox";
@@ -40,6 +42,9 @@ const TeamDetail = ({ match }: RouteComponentProps<PageParams>) => {
     const teamCode = match.params.code.toUpperCase();
     const teamInfoError = useSelector(teamInfoErrorSelector);
     const orderError = useSelector(errorSelector);
+    const creditsAvailable = useSelector(teamStartingCreditsSelector);
+    const creditsUsed = useSelector(getCreditsUsedSelector);
+    const creditsRemaining = creditsAvailable ? creditsAvailable - creditsUsed : 0;
 
     const updateParticipantIdError = useSelector(updateParticipantIdErrorSelector);
     if (
@@ -70,7 +75,10 @@ const TeamDetail = ({ match }: RouteComponentProps<PageParams>) => {
             ) : (
                 <Grid container direction="column" spacing={6}>
                     <Grid item xs={12}>
-                        <Typography variant="h1">Team {teamCode} Overview</Typography>
+                        <Typography variant="h1">
+                            Team {teamCode} Overview - (🪙 {creditsRemaining} Credits
+                            Left)
+                        </Typography>
                     </Grid>
                     <Grid
                         item

--- a/hackathon_site/dashboard/frontend/src/pages/TeamDetail/TeamDetail.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/TeamDetail/TeamDetail.tsx
@@ -76,7 +76,7 @@ const TeamDetail = ({ match }: RouteComponentProps<PageParams>) => {
                 <Grid container direction="column" spacing={6}>
                     <Grid item xs={12}>
                         <Typography variant="h1">
-                            Team {teamCode} Overview - (🪙 {creditsRemaining} Credits
+                            Team {teamCode} Overview - (💳 {creditsRemaining} Credits
                             Left)
                         </Typography>
                     </Grid>

--- a/hackathon_site/dashboard/frontend/src/slices/event/teamDetailSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/event/teamDetailSlice.ts
@@ -8,6 +8,7 @@ import { AppDispatch, RootState } from "slices/store";
 import { displaySnackbar } from "slices/ui/uiSlice";
 import { get, patch } from "api/api";
 import { Profile, ProfileWithUser, Team } from "api/types";
+import { startingCredits } from "constants.js";
 
 interface TeamDetailExtraState {
     isTeamInfoLoading: boolean;
@@ -15,6 +16,7 @@ interface TeamDetailExtraState {
     teamInfoError: string | null;
     participantIdError: string | null;
     projectDescription: string | null;
+    credits: number;
 }
 
 const extraState: TeamDetailExtraState = {
@@ -23,6 +25,7 @@ const extraState: TeamDetailExtraState = {
     teamInfoError: null,
     participantIdError: null,
     projectDescription: null,
+    credits: startingCredits,
 };
 
 const teamDetailAdapter = createEntityAdapter<ProfileWithUser>();
@@ -157,6 +160,7 @@ const teamDetailSlice = createSlice({
             state.teamInfoError = null;
 
             state.projectDescription = payload.project_description;
+            state.credits = payload.credits;
             teamDetailAdapter.setAll(state, payload.profiles);
         });
         builder.addCase(getTeamInfoData.rejected, (state, { payload }) => {
@@ -235,4 +239,9 @@ export const updateParticipantIdErrorSelector = createSelector(
 export const projectDescriptionSelector = createSelector(
     [teamDetailSliceSelector],
     (teamDetailSlice) => teamDetailSlice.projectDescription
+);
+
+export const teamStartingCreditsSelector = createSelector(
+    [teamDetailSliceSelector],
+    (teamDetailSlice) => teamDetailSlice.credits
 );

--- a/hackathon_site/dashboard/frontend/src/slices/order/teamOrderSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/order/teamOrderSlice.ts
@@ -17,6 +17,7 @@ interface TeamOrderExtraState {
     hardwareIdsToFetch: number[] | null;
     returnedOrders: ReturnOrderInTable[];
     returnedIsLoading: boolean;
+    creditsUsed: number;
 }
 
 export interface UpdateOrderAttributes {
@@ -34,6 +35,7 @@ const extraState: TeamOrderExtraState = {
     hardwareIdsToFetch: null,
     returnedOrders: [],
     returnedIsLoading: false,
+    creditsUsed: 0,
 };
 
 const teamOrders = createEntityAdapter<OrderInTable>();
@@ -206,10 +208,12 @@ const teamOrderSlice = createSlice({
                 checkedOutOrders,
                 returnedOrders,
                 hardwareIdsToFetch,
+                creditsUsed,
             } = teamOrderListSerialization(payload.results);
             teamOrders.setAll(state, [...pendingOrders, ...checkedOutOrders]);
             state.returnedOrders = returnedOrders;
             state.hardwareIdsToFetch = hardwareIdsToFetch;
+            state.creditsUsed = creditsUsed;
         });
         builder.addCase(getAdminTeamOrders.rejected, (state, { payload }) => {
             state.isLoading = false;
@@ -310,4 +314,9 @@ export const checkedOutOrdersSelector = createSelector(
 export const returnedOrdersSelector = createSelector(
     [teamOrderSliceSelector],
     (teamOrderSlice) => teamOrderSlice.returnedOrders
+);
+
+export const getCreditsUsedSelector = createSelector(
+    [teamOrderSliceSelector],
+    (teamOrderSlice) => teamOrderSlice.creditsUsed
 );

--- a/hackathon_site/dashboard/frontend/src/slices/order/teamOrderSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/order/teamOrderSlice.ts
@@ -7,7 +7,13 @@ import {
 import { OrderStatus } from "api/types";
 import { AppDispatch, RootState } from "slices/store";
 import { get, post, patch } from "api/api";
-import { APIListResponse, Order, OrderInTable, ReturnOrderInTable } from "api/types";
+import {
+    APIListResponse,
+    Order,
+    OrderInTable,
+    ReturnOrderInTable,
+    PartReturnedHealth,
+} from "api/types";
 import { displaySnackbar } from "slices/ui/uiSlice";
 import { teamOrderListSerialization } from "api/helpers";
 
@@ -124,7 +130,7 @@ export const returnItems = createAsyncThunk<
                     },
                 })
             );
-            dispatch(getAdminTeamOrders(response.data.team_code));
+            // dispatch(getAdminTeamOrders(response.data.team_code));
             return response.data;
         } catch (e: any) {
             const message =
@@ -168,7 +174,7 @@ export const updateOrderStatus = createAsyncThunk<
                     },
                 })
             );
-            dispatch(getAdminTeamOrders(response.data.team_code));
+            // dispatch(getAdminTeamOrders(response.data.team_code));
             return response.data;
         } catch (e: any) {
             const message =
@@ -224,11 +230,105 @@ const teamOrderSlice = createSlice({
         builder.addCase(returnItems.pending, (state) => {
             state.returnedIsLoading = true;
         });
-        builder.addCase(returnItems.fulfilled, (state, { payload }) => {
+        builder.addCase(returnItems.fulfilled, (state, { payload, meta }) => {
+            // Mark that the return operation is no longer loading.
             state.returnedIsLoading = false;
+
+            // --- Error Handling ---
+            if (payload.errors && payload.errors.length > 0) {
+                state.error = payload.errors.map((err) => err.message).join(" | ");
+            } else {
+                state.error = null;
+            }
+
+            // --- Update Returned Orders ---
+            if (payload.returned_items && payload.returned_items.length > 0) {
+                const returnItemsData = meta.arg; // ReturnOrderRequest
+
+                const hardwareInOrder = payload.returned_items.map((item) => {
+                    const correspondingRequestItem = returnItemsData.hardware.find(
+                        (hardware) => hardware.id === item.hardware_id
+                    );
+                    const partReturnedHealth: PartReturnedHealth | null =
+                        correspondingRequestItem
+                            ? (correspondingRequestItem.part_returned_health as PartReturnedHealth)
+                            : null;
+
+                    return {
+                        id: item.hardware_id,
+                        hardware_id: item.hardware_id,
+                        quantity: item.quantity,
+                        part_returned_health: partReturnedHealth,
+                        time: `${new Date().toLocaleTimeString()} (${new Date().toDateString()})`,
+                    };
+                });
+
+                const existingReturnedOrder = state.returnedOrders.find(
+                    (order) => order.id === payload.order_id
+                );
+
+                if (existingReturnedOrder) {
+                    hardwareInOrder.forEach((newItem) => {
+                        const existingHardwareItem =
+                            existingReturnedOrder.hardwareInOrder.find(
+                                (existingItem) =>
+                                    existingItem.hardware_id === newItem.hardware_id &&
+                                    existingItem.part_returned_health ===
+                                        newItem.part_returned_health
+                            );
+                        if (existingHardwareItem) {
+                            existingHardwareItem.quantity += newItem.quantity;
+                        } else {
+                            existingReturnedOrder.hardwareInOrder.push(newItem);
+                        }
+                    });
+                } else {
+                    state.returnedOrders.push({
+                        id: payload.order_id,
+                        hardwareInOrder,
+                    });
+                }
+            }
+
+            // --- Update Checked Out Orders in the teamOrders Adapter ---
+            // Find the order entity that is being partially returned.
+            const orderToUpdate = state.entities[payload.order_id];
+            if (orderToUpdate) {
+                // For each hardware row in the order, subtract any returned quantity.
+                // Note: This example assumes that the row.id corresponds to the hardware id.
+                const updatedHardwareInTableRow = orderToUpdate.hardwareInTableRow
+                    .map((row) => {
+                        // Sum up the total returned quantity for this hardware (regardless of part_returned_health,
+                        // since the checked out order row typically doesn’t store health info).
+                        const totalReturnedForHardware = payload.returned_items
+                            .filter((ri) => ri.hardware_id === row.id)
+                            .reduce((sum, ri) => sum + ri.quantity, 0);
+
+                        // Subtract the returned quantity from the quantityGranted.
+                        return {
+                            ...row,
+                            quantityGranted:
+                                row.quantityGranted - totalReturnedForHardware,
+                        };
+                    })
+                    // Remove rows that now have zero quantity.
+                    .filter((row) => row.quantityGranted > 0);
+
+                // Update the order in the adapter.
+                teamOrders.updateOne(state, {
+                    id: payload.order_id,
+                    changes: {
+                        hardwareInTableRow: updatedHardwareInTableRow,
+                    },
+                });
+            }
         });
+
         builder.addCase(returnItems.rejected, (state, { payload }) => {
             state.returnedIsLoading = false;
+            state.error =
+                payload?.message ??
+                "There was a problem returning orders. If this continues please contact hackathon organizers.";
         });
 
         builder.addCase(updateOrderStatus.pending, (state) => {
@@ -241,7 +341,14 @@ const teamOrderSlice = createSlice({
             const { pendingOrders } = teamOrderListSerialization([payload]);
             let updateObject;
             if (pendingOrders.length > 0) {
-                const { hardwareInTableRow } = pendingOrders[0];
+                // Extract the hardware rows and filter out rows where quantityGranted is 0
+                let { hardwareInTableRow } = pendingOrders[0];
+                // Only filter out rows with quantityGranted 0 if the new status is "Picked Up".
+                if (payload.status === "Ready for Pickup") {
+                    hardwareInTableRow = hardwareInTableRow.filter(
+                        (row) => row.quantityGranted > 0
+                    );
+                }
 
                 updateObject = {
                     id: payload.id,


### PR DESCRIPTION
## Overview

- add credits to product overview page
![image](https://github.com/user-attachments/assets/51c90162-6bed-4a9f-9d7c-bdf6dfa67711)
- add credits and subtotalCredits for each order in TeamDetail
- properly handle state changes for returnItems thunk and updateOrderStatus thunk
- add over credits chip status for pending order for teams that have ordered more than their limit(shouldn't normally be possible)
![image](https://github.com/user-attachments/assets/949a9154-66fe-4cc9-889e-42b15aeb0c8b)

## Unit Tests Created

- n/a


## Steps to QA

- check inventory page and click product overview
- Check TeamDetail.tsx and adjust quantities and dynamically see credits and subtotal credits update
- test partial return orders, and returning multiple orders and adjusting quantities

